### PR TITLE
Fix helm command to install MCAD

### DIFF
--- a/Quick-Start.md
+++ b/Quick-Start.md
@@ -42,7 +42,7 @@ Fist we will use [Helm](https://helm.sh/) to install MCAD. (Make sure you have H
 git clone https://github.com/project-codeflare/multi-cluster-app-dispatcher.git 
 helm list -n kube-system
 cd multi-cluster-app-dispatcher/deployment/mcad-controller/
-helm upgrade --install --wait mcad . --namespace kube-system --set loglevel=4 image.repository=quay.io/project-codeflare/mcad-controller --set image.tag=main-v1.29.50 --set image.pullPolicy=Always --set configMap.name=mcad-controller-configmap --set configMap.quotaEnabled='"false"' --set coscheduler.rbac.apiGroup="scheduling.sigs.k8s.io" --set coscheduler.rbac.resource="podgroups"
+helm upgrade --install --wait mcad . --namespace kube-system --set loglevel=4 --set image.repository=quay.io/project-codeflare/mcad-controller --set image.tag=main-v1.29.50 --set image.pullPolicy=Always --set configMap.name=mcad-controller-configmap --set configMap.quotaEnabled='"false"' --set coscheduler.rbac.apiGroup="scheduling.sigs.k8s.io" --set coscheduler.rbac.resource="podgroups"
 cd ../../..
 rm -rf multi-cluster-app-dispatcher
 ```


### PR DESCRIPTION
Fix an mcad installation error

## Description
Add missing `--set` flag

## How Has This Been Tested?
Add the `--set` flag and verify the `Error: "helm upgrade" requires 2 arguments` goes away and verified message below:
```
NAME: mcad
LAST DEPLOYED: Mon Feb  6 16:44:29 2023
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
