### PR TITLE
Add testing template

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,99 @@
+# Running Tests Manually
+
+Manually running tests requires use of the the [opendatahub-io/peak](https://github.com/opendatahub-io/peak) project.
+
+## Prerequisites
+
+* Admin access to an OpenShift cluster ([CRC](https://developers.redhat.com/products/openshift-local/overview) is fine)
+
+* Mac users may need to do the following:
+```bash
+brew install coreutils
+ln -s /usr/local/bin/greadlink /usr/local/bin/readlink
+```
+
+## Setup
+
+Clone the [opendatahub-io/peak](https://github.com/opendatahub-io/peak) project anywhere you like in your working environment. But, do not clone it into the `distributed-workloads` directory.
+
+```bash
+git clone https://github.com/opendatahub-io/peak
+cd peak
+```
+
+Then we need to update the peak project with its submodule dependencies. Specifically, [opendatahub-io/openshift-test-kit](https://github.com/opendatahub-io/openshift-test-kit/tree/0e469c4bf967b531780eb05d6b96463214288db7) defined in the `.gitmodules` file.
+
+```bash
+git submodule update --init
+``` 
+
+Now we need to pull our `distributed workloads` project into the peak repo for testing. This is done by creating a file, `my-list`, that contains the repository name you want to use, the channel, the repo's location (this can be a github url or a relative path to a local directory) and branch name.
+
+For example, if you cloned peak into the same directory level as `distributed-workloads`, then you would create a file, `my-list`, in the following way:
+
+```bash
+echo distributed-workloads nil ../distributed-workloads main > my-list
+```
+
+Now we can setup our tests.
+
+```bash
+./setup.sh -t my-list
+```
+
+This should create a directory, `distributed-workloads` in the `operator-tests` directory of the peak repo.
+
+## Running Tests
+
+Our tests script needs be executable. So, we need to change permissions on the `distributed-workloads.sh` script.
+
+```bash
+chmod +x operator-tests/distributed-workloads/tests/basictests/distributed-workloads.sh
+```
+
+We can now run our test script! 
+
+`run.sh` will search through the 'operator-tests' directory for a *.sh file name we provide to it as an argument. In this case, we want to run the `distributed-workloads.sh` script.
+
+```bash
+./run.sh distributed-workloads.sh
+```
+If everything is working correctly you should see an output similar to the below:
+
+```bash
+Running example test
+
+Running operator-tests/distributed-workloads/tests/basictests/distributed-workloads.sh:15: executing 'oc project opendatahub' expecting success...
+
+
+✔ SUCCESS after 0.184s: operator-tests/distributed-workloads/tests/basictests/distributed-workloads.sh:15: executing 'oc project opendatahub' expecting success
+
+Running operator-tests/distributed-workloads/tests/basictests/distributed-workloads.sh:16: executing 'oc get pods' expecting success...
+
+
+✔ SUCCESS after 0.127s: operator-tests/distributed-workloads/tests/basictests/distributed-workloads.sh:16: executing 'oc get pods' expecting success
+
+
+Installing Codeflare Operator
+
+
+Installing distributed workloads kfdef
+
+
+Testing MCAD TorchX Functionality
+
+
+Testing MCAD Ray Functionality
+
+
+Uninstalling distributed workloads kfdef
+
+
+Uninstalling Codeflare Operator
+
+```
+
+
+## Troubleshooting
+
+If any of the above is unclear or you run into any problems, please open an issue in the [opendatahub-io/distributed-workloads](https://github.com/opendatahub-io/distributed-workloads/issues) repository. 

--- a/tests/basictests/distributed-workloads.sh
+++ b/tests/basictests/distributed-workloads.sh
@@ -6,16 +6,16 @@ MY_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 
 RESOURCEDIR="${MY_DIR}/../resources"
 
-source ${MY_DIR}/../util
+source ${MY_DIR}/../../util
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 function install_codeflare_operator() {
-    header: "Installing Codeflare Operator"
+    header "Installing Codeflare Operator"
 }
 
 function install_distributed_workloads_kfdef(){
-    header: "Installing distributed workloads kfdef"
+    header "Installing distributed workloads kfdef"
     os::cmd::expect_success "oc apply -f ../distributed-workloads-kfdef.yaml"
     os::cmd::expect_success "oc project opendatahub"
     
@@ -30,24 +30,24 @@ function install_distributed_workloads_kfdef(){
 }
 
 function test_mcad_torchx_functionality() {
-    header: "Testing MCAD TorchX Functionality" 
+    header "Testing MCAD TorchX Functionality" 
 }
 
 function tests_mcad_ray_functionality() {
-    header: "Testing MCAD Ray Functionality"
+    header "Testing MCAD Ray Functionality"
 }    
 
 function uninstall_distributed_workloads_kfdef() {
-    header: "Uninstalling distributed workloads kfdef"
+    header "Uninstalling distributed workloads kfdef"
 }
 
 function uninstall_codeflare_operator() {
-    header: "Uninstalling Codeflare Operator"
+    header "Uninstalling Codeflare Operator"
 }
 
 
 install_codeflare_operator
-install_distributred_workloads_kfdef
+install_distributed_workloads_kfdef
 test_mcad_torchx_functionality
 tests_mcad_ray_functionality
 uninstall_distributed_workloads_kfdef

--- a/tests/basictests/distributed-workloads.sh
+++ b/tests/basictests/distributed-workloads.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+source $TEST_DIR/common
+
+MY_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
+
+RESOURCEDIR="${MY_DIR}/../resources"
+
+source ${MY_DIR}/../util
+
+os::test::junit::declare_suite_start "$MY_SCRIPT"
+
+function install_codeflare_operator() {
+    header: "Installing Codeflare Operator"
+}
+
+function install_distributed_workloads_kfdef(){
+    header: "Installing distributed workloads kfdef"
+    os::cmd::expect_success "oc apply -f ../distributed-workloads-kfdef.yaml"
+    os::cmd::expect_success "oc project opendatahub"
+    
+    # KubeRay tests
+    os::cmd::try_until_text "oc get crd rayclusters.ray.io" "rayclusters.ray.io" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get role kuberay-operator-leader-election" "kuberay-operator-leader-election" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get rolebinding kuberay-operator-leader-election" "kuberay-operator-leader-election" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get sa kuberay-operator" "kuberay-operator" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get deployment kuberay-operator" "kuberay-operator" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get pods -l app.kubernetes.io/component=kuberay-operator --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}' | wc -w" "1" $odhdefaulttimeout $odhdefaultinterval   
+
+}
+
+function test_mcad_torchx_functionality() {
+    header: "Testing MCAD TorchX Functionality" 
+}
+
+function tests_mcad_ray_functionality() {
+    header: "Testing MCAD Ray Functionality"
+}    
+
+function uninstall_distributed_workloads_kfdef() {
+    header: "Uninstalling distributed workloads kfdef"
+}
+
+function uninstall_codeflare_operator() {
+    header: "Uninstalling Codeflare Operator"
+}
+
+
+install_codeflare_operator
+install_distributred_workloads_kfdef
+test_mcad_torchx_functionality
+tests_mcad_ray_functionality
+uninstall_distributed_workloads_kfdef
+uninstall_codeflare_operator
+
+
+os::test::junit::declare_suite_end

--- a/tests/basictests/distributed-workloads.sh
+++ b/tests/basictests/distributed-workloads.sh
@@ -6,27 +6,22 @@ MY_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 
 RESOURCEDIR="${MY_DIR}/../resources"
 
-source ${MY_DIR}/../../util
+source ${MY_DIR}/../util
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
+
+function example_test() {
+    header "Running example test"
+    os::cmd::expect_success "oc project ${ODHPROJECT}"
+    os::cmd::expect_success "oc get pods"
+}
 
 function install_codeflare_operator() {
     header "Installing Codeflare Operator"
 }
 
 function install_distributed_workloads_kfdef(){
-    header "Installing distributed workloads kfdef"
-    os::cmd::expect_success "oc apply -f ../distributed-workloads-kfdef.yaml"
-    os::cmd::expect_success "oc project opendatahub"
-    
-    # KubeRay tests
-    os::cmd::try_until_text "oc get crd rayclusters.ray.io" "rayclusters.ray.io" $odhdefaulttimeout $odhdefaultinterval
-    os::cmd::try_until_text "oc get role kuberay-operator-leader-election" "kuberay-operator-leader-election" $odhdefaulttimeout $odhdefaultinterval
-    os::cmd::try_until_text "oc get rolebinding kuberay-operator-leader-election" "kuberay-operator-leader-election" $odhdefaulttimeout $odhdefaultinterval
-    os::cmd::try_until_text "oc get sa kuberay-operator" "kuberay-operator" $odhdefaulttimeout $odhdefaultinterval
-    os::cmd::try_until_text "oc get deployment kuberay-operator" "kuberay-operator" $odhdefaulttimeout $odhdefaultinterval
-    os::cmd::try_until_text "oc get pods -l app.kubernetes.io/component=kuberay-operator --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}' | wc -w" "1" $odhdefaulttimeout $odhdefaultinterval   
-
+    header "Installing distributed workloads kfdef"   
 }
 
 function test_mcad_torchx_functionality() {
@@ -46,6 +41,7 @@ function uninstall_codeflare_operator() {
 }
 
 
+example_test
 install_codeflare_operator
 install_distributed_workloads_kfdef
 test_mcad_torchx_functionality

--- a/tests/resources/test_mcad_ray.py
+++ b/tests/resources/test_mcad_ray.py
@@ -1,0 +1,7 @@
+# Import pieces from codeflare_sdk
+from codeflare_sdk.cluster.cluster import Cluster, ClusterConfiguration
+from codeflare_sdk.cluster.auth import TokenAuthentication
+
+
+def test_sdk_functionality():
+    pass

--- a/tests/util
+++ b/tests/util
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Change this if your project is not named opendatahub
+export ODHPROJECT=${ODHPROJECT:-"opendatahub"}
+
+millisecond=1
+second=$(( 1000 * millisecond ))
+minute=$(( 60 * second ))
+fiveminute=$(( 300 * second ))
+odhdefaulttimeout=$(( 1200 * second ))
+odhdefaultinterval=$(( 10 ))
+
+function header() {
+    os::text::print_blue $1
+}


### PR DESCRIPTION
This PR adds a testing template we can use to build our e2e tests for the distributed workloads/CodeFlare Stack.

* The template includes an empty function for each of the test issues we outlined on our [issues](https://github.com/opendatahub-io/distributed-workloads/issues) page. But feel free to supplement with more supporting functions if needed. 

* I added a small subset of tests for the KubeRay operator to get us started and provide an example of how to write tests in this format. 

* There is also a `resources` directory where we can add whatever scripts, yaml files, etc we will need during testing. It is currently just populated with template python file. 
  