### PR TITLE
E2E CodeFlare delete portion

### DIFF
--- a/tests/basictests/distributed-workloads.sh
+++ b/tests/basictests/distributed-workloads.sh
@@ -38,6 +38,27 @@ function uninstall_distributed_workloads_kfdef() {
 
 function uninstall_codeflare_operator() {
     header "Uninstalling Codeflare Operator"
+    # Figure out the csv name of the codeflare operator
+    CODEFLARE_CSV_VER=$(oc get csv | awk '{print $1}' |grep codeflare-operator)
+
+    # Uninstall the subscription, csv and crds of the CodeFlare Operator
+    os::cmd::expect_success "oc delete sub codeflare-operator -n openshift-operators"
+    os::cmd::expect_success "oc delete csv $CODEFLARE_CSV_VER -n openshift-operators"
+    os::cmd::expect_success "oc delete crd appwrappers.mcad.ibm.com instascales.codeflare.codeflare.dev mcads.codeflare.codeflare.dev queuejobs.mcad.ibm.com schedulingspecs.mcad.ibm.com"
+
+    # Wait until the CodeFlare Operator pods is gone
+    os::cmd::try_until_text "oc get pods -n openshift-operators -l control-plane=controller-manager" "No resources found in openshift-operators namespace." $odhdefaulttimeout $odhdefaultinterval
+
+    # Ensure that the CodeFlare Operator subscription and csv are deleted
+    os::cmd::expect_failure "oc get sub codeflare-operator -n openshift-operators"
+    os::cmd::expect_failure "oc get csv codeflare-operator.v0.0.1 -n openshift-operators"
+
+    # Ensure that all CRDs are deleted
+    os::cmd::expect_failure "oc get crd instascales.codeflare.codeflare.dev"
+    os::cmd::expect_failure "oc get crd mcads.codeflare.codeflare.dev"
+    os::cmd::expect_failure "oc get crd appwrappers.mcad.ibm.com"
+    os::cmd::expect_failure "oc get crd queuejobs.mcad.ibm.com"
+    os::cmd::expect_failure "oc get crd schedulingspecs.mcad.ibm.com"
 }
 
 


### PR DESCRIPTION
## Description
This solves E2E Step6 "Uninstall CodeFlare Operator" https://github.com/opendatahub-io/distributed-workloads/issues/20 

It goes hand and hand with the code written in Kevin's PR https://github.com/opendatahub-io/distributed-workloads/pull/22 

It essentially 
- Figures out what the version of the CodeFlare Operator csv currently is
- Uninstalls the subscription, csv and all the crds associated with the CodeFlare Operator
- Waits until the CodeFlare Operator pod is really gone
- Then it checks to ensure that the subscription, csv and the crds are really all gone

## How Has This Been Tested?
Using peak, and with an already installed codeflare operator, I've been running the test script with success.  Here's the test detail:
```
./run.sh 
++++++ /root/MICHAEL/distributed-workloads/peak/operator-tests/opendatahub-kubeflow/tests/basictests
Now using project "basictests-badv" on server "https://api.jimbig4127.cp.fyre.ibm.com:6443".

++++ /root/MICHAEL/distributed-workloads/peak/operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh

Running example test

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:15: executing 'oc project opendatahub' expecting success...


✔ SUCCESS after 0.182s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:15: executing 'oc project opendatahub' expecting success

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:16: executing 'oc get pods' expecting success...


✔ SUCCESS after 0.143s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:16: executing 'oc get pods' expecting success


Installing distributed workloads kfdef


Testing MCAD TorchX Functionality


Testing MCAD Ray Functionality


Uninstalling distributed workloads kfdef


Uninstalling Codeflare Operator

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:56: executing 'oc delete sub codeflare-operator -n openshift-operators' expecting success...


✔ SUCCESS after 0.158s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:56: executing 'oc delete sub codeflare-operator -n openshift-operators' expecting success

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:57: executing 'oc delete csv codeflare-operator.v0.0.1 -n openshift-operators' expecting success...


✔ SUCCESS after 0.171s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:57: executing 'oc delete csv codeflare-operator.v0.0.1 -n openshift-operators' expecting success

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:58: executing 'oc delete crd appwrappers.mcad.ibm.com instascales.codeflare.codeflare.dev mcads.codeflare.codeflare.dev queuejobs.mcad.ibm.com schedulingspecs.mcad.ibm.com' expecting success...


✔ SUCCESS after 0.789s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:58: executing 'oc delete crd appwrappers.mcad.ibm.com instascales.codeflare.codeflare.dev mcads.codeflare.codeflare.dev queuejobs.mcad.ibm.com schedulingspecs.mcad.ibm.com' expecting success

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:61: executing 'oc get pods -n openshift-operators -l control-plane=controller-manager' expecting any result and text 'No resources found in openshift-operators namespace.'; re-trying every 10s until completion or 1200.000s...


✔ SUCCESS after 10.319s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:61: executing 'oc get pods -n openshift-operators -l control-plane=controller-manager' expecting any result and text 'No resources found in openshift-operators namespace.'; re-trying every 10s until completion or 1200.000s

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:64: executing 'oc get sub codeflare-operator -n openshift-operators' expecting failure...


✔ SUCCESS after 0.140s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:64: executing 'oc get sub codeflare-operator -n openshift-operators' expecting failure

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:65: executing 'oc get csv codeflare-operator.v0.0.1 -n openshift-operators' expecting failure...


✔ SUCCESS after 0.154s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:65: executing 'oc get csv codeflare-operator.v0.0.1 -n openshift-operators' expecting failure

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:68: executing 'oc get crd instascales.codeflare.codeflare.dev' expecting failure...


✔ SUCCESS after 0.153s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:68: executing 'oc get crd instascales.codeflare.codeflare.dev' expecting failure

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:69: executing 'oc get crd mcads.codeflare.codeflare.dev' expecting failure...


✔ SUCCESS after 0.166s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:69: executing 'oc get crd mcads.codeflare.codeflare.dev' expecting failure

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:70: executing 'oc get crd appwrappers.mcad.ibm.com' expecting failure...


✔ SUCCESS after 0.161s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:70: executing 'oc get crd appwrappers.mcad.ibm.com' expecting failure

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:71: executing 'oc get crd queuejobs.mcad.ibm.com' expecting failure...


✔ SUCCESS after 0.173s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:71: executing 'oc get crd queuejobs.mcad.ibm.com' expecting failure

Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:72: executing 'oc get crd schedulingspecs.mcad.ibm.com' expecting failure...


✔ SUCCESS after 0.134s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:72: executing 'oc get crd schedulingspecs.mcad.ibm.com' expecting failure

Already on project "opendatahub" on server "https://api.jimbig4127.cp.fyre.ibm.com:6443".
./run.sh took 15 seconds
[INFO] Exiting with 0
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
