### PR TITLE
Adding kfdef add and delete

### DIFF
--- a/tests/basictests/distributed-workloads.sh
+++ b/tests/basictests/distributed-workloads.sh
@@ -36,9 +36,9 @@ function install_distributed_workloads_kfdef(){
     os::cmd::expect_success "oc apply -f https://raw.githubusercontent.com/opendatahub-io/distributed-workloads/main/codeflare-stack-kfdef.yaml -n ${ODHPROJECT}"
 
     # Ensure that MCAD, Instascale, KubeRay pods start
-    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} |grep mcad-controller | awk '{print \$3}'"  "Running"
-    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} |grep instascale-instascale | awk '{print \$3}'"  "Running"
-    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} |grep kuberay-operator | awk '{print \$3}'"  "Running"
+    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} |grep mcad-controller | awk '{print \$2}'"  "1/1" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} |grep instascale-instascale | awk '{print \$2}'"  "1/1" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} |grep kuberay-operator | awk '{print \$2}'"  "1/1" $odhdefaulttimeout $odhdefaultinterval
 
     # Ensure the codeflare-notebook imagestream is there
     os::cmd::expect_success_and_text "oc get imagestreams -n ${ODHPROJECT} codeflare-notebook --no-headers=true |awk '{print \$1}'"  "codeflare-notebook"
@@ -80,12 +80,13 @@ function tests_mcad_ray_functionality() {
 
 function uninstall_distributed_workloads_kfdef() {
     header "Uninstalling distributed workloads kfdef"
-    os::cmd::expect_success "oc delete kfdef codeflare-stack -n ${ODHPROJECT}"
+    echo "NOTE, kfdef deletion can take up to 5-8 minutes..."
+    os::cmd::try_until_success "oc delete kfdef codeflare-stack -n ${ODHPROJECT}" $odhdefaulttimeout $odhdefaultinterval
 
     # Ensure that MCAD, Instascale, KubeRay pods are gone
-    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} -l app=mcad-mcad" "No resources found in ${ODHPROJECT} namespace."
-    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} -l app=instascale-instascale" "No resources found in ${ODHPROJECT} namespace."
-    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} -l app.kubernetes.io/component=kuberay-operator" "No resources found in ${ODHPROJECT} namespace."
+    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} -l app=mcad-mcad" "No resources found in ${ODHPROJECT} namespace." $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} -l app=instascale-instascale" "No resources found in ${ODHPROJECT} namespace." $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} -l app.kubernetes.io/component=kuberay-operator" "No resources found in ${ODHPROJECT} namespace." $odhdefaulttimeout $odhdefaultinterval
 
     # Ensure the codeflare-notebook imagestream is removed
     os::cmd::expect_failure "oc get imagestreams -n ${ODHPROJECT} codeflare-notebook"

--- a/tests/basictests/distributed-workloads.sh
+++ b/tests/basictests/distributed-workloads.sh
@@ -33,7 +33,7 @@ function install_codeflare_operator() {
 
 function install_distributed_workloads_kfdef(){
     header "Installing distributed workloads kfdef"
-    os::cmd::expect_success "oc apply -f https://raw.githubusercontent.com/opendatahub-io/distributed-workloads/main/codeflare-stack-kfdef.yaml -n ${ODHPROJECT}"
+    os::cmd::expect_success "oc apply -f $MY_DIR/../../codeflare-stack-kfdef.yaml -n ${ODHPROJECT}"
 
     # Ensure that MCAD, Instascale, KubeRay pods start
     os::cmd::try_until_text "oc get pod -n ${ODHPROJECT} |grep mcad-controller | awk '{print \$2}'"  "1/1" $odhdefaulttimeout $odhdefaultinterval
@@ -115,11 +115,6 @@ function uninstall_codeflare_operator() {
     os::cmd::expect_failure "oc get crd appwrappers.mcad.ibm.com"
     os::cmd::expect_failure "oc get crd queuejobs.mcad.ibm.com"
     os::cmd::expect_failure "oc get crd schedulingspecs.mcad.ibm.com"
-}
-
-
-function uninstall_codeflare_operator() {
-    header "Uninstalling Codeflare Operator"
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR applies and deletes the  kfdef issues https://github.com/opendatahub-io/distributed-workloads/issues/16 and https://github.com/opendatahub-io/distributed-workloads/issues/19

It requires the CodeFlare Operator to already be installed, (which Kevin is taking care of in his PR #22

Then, my portion of the E2E test (section install_distributed_workloads_kfdef) does the following:
1.  Installs the kfdef
2. Makes sure the 3 expected pods (mcad-controller, instascale and kuberay operator) are running.  (NOTE - Once the KFDEF has Instascale as optional, or if we have two KFDEFs, then this test might need to be slighly modified to account for that.)
3. It makes sure the codeflare-nodebook imagestream is there

Then, my portion of the E2E test (section uninstall_distributed_workloads_kfdef) does the following:
1. Uninstalls the kfdef. (Note, this can take up to 300+ seconds, depending on where in the reconcile loop the MCAD controller is at.
2. Checks to make sure all three pods are gone.
3. It makes sure the codeflare-nodebook imagestream is removed.

## How Has This Been Tested?
I have been modifying and running the E2E test with peak/run.sh.  I'll pull fresh my PR and post the test results below before I take the PR out of draft form.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
