### PR TITLE
add Containerfile for mcad mnist test

### DIFF
--- a/tests/resources/mcad-mnist-tests-Containerfile
+++ b/tests/resources/mcad-mnist-tests-Containerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/pytorch/torchx:0.5.0dev0
+
+ADD mnist.py /app/mnist.py
+
+# change group permissions for running in OCP
+RUN chgrp -R 0 /app
+RUN chmod -R g+w /app
+
+ENTRYPOINT ["python", "/app/mnist.py"]


### PR DESCRIPTION
Added Containerfile used to build image for testing MCAD job submission functionality. 

Depends on `mnist.py` in #31 