### PR TITLE
uninstall_codeflare_operator function has problem with pod deletion test

### DIFF
--- a/tests/basictests/distributed-workloads.sh
+++ b/tests/basictests/distributed-workloads.sh
@@ -183,8 +183,8 @@ function uninstall_codeflare_operator() {
     os::cmd::expect_success "oc delete csv $CODEFLARE_CSV_VER -n openshift-operators"
     os::cmd::expect_success "oc delete crd appwrappers.mcad.ibm.com instascales.codeflare.codeflare.dev mcads.codeflare.codeflare.dev queuejobs.mcad.ibm.com schedulingspecs.mcad.ibm.com"
 
-    # Wait until the CodeFlare Operator pods is gone
-    os::cmd::try_until_text "oc get pods -n openshift-operators -l control-plane=controller-manager" "No resources found in openshift-operators namespace." $odhdefaulttimeout $odhdefaultinterval
+    # Wait until the CodeFlare Operator deployment is gone
+    os::cmd::try_until_text "oc get deploy mcad-controller-mcad -n ${ODHPROJECT}" "*NotFound*" $odhdefaulttimeout $odhdefaultinterval
 
     # Ensure that the CodeFlare Operator subscription and csv are deleted
     os::cmd::expect_failure "oc get sub codeflare-operator -n openshift-operators"

--- a/tests/basictests/distributed-workloads.sh
+++ b/tests/basictests/distributed-workloads.sh
@@ -171,6 +171,9 @@ function uninstall_distributed_workloads_kfdef() {
 
     # Ensure the codeflare-notebook imagestream is removed
     os::cmd::expect_failure "oc get imagestreams -n ${ODHPROJECT} codeflare-notebook"
+
+    # Delete the underlying notebook pvc
+    os::cmd::expect_success "oc delete pvc jupyterhub-nb-kube-3aadmin-pvc -n ${ODHPROJECT}"
 }
 
 function uninstall_codeflare_operator() {

--- a/tests/basictests/distributed-workloads.sh
+++ b/tests/basictests/distributed-workloads.sh
@@ -184,7 +184,7 @@ function uninstall_codeflare_operator() {
     os::cmd::expect_success "oc delete crd appwrappers.mcad.ibm.com instascales.codeflare.codeflare.dev mcads.codeflare.codeflare.dev queuejobs.mcad.ibm.com schedulingspecs.mcad.ibm.com"
 
     # Wait until the CodeFlare Operator deployment is gone
-    os::cmd::try_until_text "oc get deploy mcad-controller-mcad -n ${ODHPROJECT}" "*NotFound*" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get deploy codeflare-operator-controller-manager -n openshift-operators" "*NotFound*" $odhdefaulttimeout $odhdefaultinterval
 
     # Ensure that the CodeFlare Operator subscription and csv are deleted
     os::cmd::expect_failure "oc get sub codeflare-operator -n openshift-operators"

--- a/tests/basictests/distributed-workloads.sh
+++ b/tests/basictests/distributed-workloads.sh
@@ -171,9 +171,6 @@ function uninstall_distributed_workloads_kfdef() {
 
     # Ensure the codeflare-notebook imagestream is removed
     os::cmd::expect_failure "oc get imagestreams -n ${ODHPROJECT} codeflare-notebook"
-
-    # Delete the underlying notebook pvc
-    os::cmd::expect_success "oc delete pvc jupyterhub-nb-kube-3aadmin-pvc -n ${ODHPROJECT} || true"
 }
 
 function uninstall_codeflare_operator() {

--- a/tests/basictests/distributed-workloads.sh
+++ b/tests/basictests/distributed-workloads.sh
@@ -173,7 +173,7 @@ function uninstall_distributed_workloads_kfdef() {
     os::cmd::expect_failure "oc get imagestreams -n ${ODHPROJECT} codeflare-notebook"
 
     # Delete the underlying notebook pvc
-    os::cmd::expect_success "oc delete pvc jupyterhub-nb-kube-3aadmin-pvc -n ${ODHPROJECT}"
+    os::cmd::expect_success "oc delete pvc jupyterhub-nb-kube-3aadmin-pvc -n ${ODHPROJECT} || true"
 }
 
 function uninstall_codeflare_operator() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Unfortunately, I think due to the latest update of the ODH operator, the current check to ensure that the CodeFlare ] operator pod has been deleted is also catching the ODH operator and therefore the function never completes.

The change below, instead of checking for the CodeFlare Operator pod, it just checks now for the CodeFlare deployment, making sure that that has been removed before continuing.

## How Has This Been Tested?
Using the peak e2e method, I've been running the uninstall_codeflare_operator function and it's properly completing now:
```
./run.sh distributed-workloads.sh
...
Uninstalling Codeflare Operator
...
Running operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:176: executing 'oc get deploy codeflare-operator-controller-manager -n openshift-operators' expecting any result and text '*NotFound*'; re-trying every 10s until completion or 1200.000s...


✔ SUCCESS after 0.162s: operator-tests/opendatahub-kubeflow/tests/basictests/distributed-workloads.sh:176: executing 'oc get deploy codeflare-operator-controller-manager -n openshift-operators' expecting any result and text '*NotFound*'; re-trying every 10s until completion or 1200.000s
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
