### PR TITLE
CPU bump and memory decrease for custom notebook 

### DIFF
--- a/tests/resources/custom-nb-small.yaml
+++ b/tests/resources/custom-nb-small.yaml
@@ -76,10 +76,10 @@ spec:
         resources:
           limits:
             cpu: "2"
-            memory: 8Gi
+            memory: 3Gi
           requests:
             cpu: "1"
-            memory: 8Gi
+            memory: 3Gi
         volumeMounts:
         - mountPath: /opt/app-root/src
           name: jupyterhub-nb-kube-3aadmin-pvc

--- a/tests/resources/mnist_mcad_mini.ipynb
+++ b/tests/resources/mnist_mcad_mini.ipynb
@@ -21,7 +21,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "job = DDPJobDefinition(name=\"mnistjob\", script=\"mnist.py\", scheduler_args={\"namespace\": \"opendatahub\"}, j=\"1x1\", gpu=0, cpu=1, memMB=8000, image=\"quay.io/project-codeflare/mnist-job-test:v0.0.1\").submit()"
+    "job = DDPJobDefinition(name=\"mnistjob\", script=\"mnist.py\", scheduler_args={\"namespace\": \"opendatahub\"}, j=\"1x1\", gpu=0, cpu=3, memMB=4000, image=\"quay.io/project-codeflare/mnist-job-test:v0.0.1\").submit()"
    ]
   },
   {

--- a/tests/resources/mnist_ray_mini.ipynb
+++ b/tests/resources/mnist_ray_mini.ipynb
@@ -25,7 +25,7 @@
    "outputs": [],
    "source": [
     "# Create our cluster and submit appwrapper\n",
-    "cluster = Cluster(ClusterConfiguration(namespace='opendatahub', name='mnisttest', min_worker=2, max_worker=2, min_cpus=1, max_cpus=1, min_memory=4, max_memory=4, gpu=0, instascale=False))"
+    "cluster = Cluster(ClusterConfiguration(namespace='opendatahub', name='mnisttest', min_worker=2, max_worker=2, min_cpus=2, max_cpus=2, min_memory=4, max_memory=4, gpu=0, instascale=False))"
    ]
   },
   {


### PR DESCRIPTION
## Description
Described in more detail in [issue 41](https://github.com/opendatahub-io/distributed-workloads/issues/41)

I found that the CodeFlare e2e test was struggling to complete on my Fyre OpenShift cluster within the 1200 second timeouts, and also couldn't complete within a "medium" Open Shift cluster (3 worker nodes with 16GB memory and 8 cpu each)

I change three files in this PR
1.  opendatahub-kubeflow/tests/resources/custom-nb-small.yaml
reducing the memory from 8Gi to 3Gi

2.  opendatahub-kubeflow/tests/resources/mnist_mcad_mini.ipynb
Increase the cpu for performance, but reduce the memory so it fits in a medium OC cluster.

3. opendatahub-kubeflow/tests/resources/mnist_ray_mini.ipynb
Increase the cpu for better performance

## How Has This Been Tested?
I'm running this PR on my OC 4.12.7 cluster and it's running well... 

Test succeeded:
```
./run.sh took 1514 seconds
[INFO] Exiting with 0
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
