### PR TITLE
fix(doc): Update link to ODH operator installation guide

### DIFF
--- a/Quick-Start.md
+++ b/Quick-Start.md
@@ -33,7 +33,7 @@ NOTE: The above resources are just for the infrastructure pods. To be able to ru
 
 ### OpenShift and Open Data Hub
 
-This Quick Start guide assumes that you have administrator access to an OpenShift cluster and an existing Open Data Hub installation on your cluster. If you do not currently have the Open Data Hub operator installed on your cluster, you can find instructions for installing it [here](https://opendatahub.io/docs/getting-started/quick-installation.html). The default settings for the Open Data Hub Operator will suffice.
+This Quick Start guide assumes that you have administrator access to an OpenShift cluster and an existing Open Data Hub installation on your cluster. If you do not currently have the Open Data Hub operator installed on your cluster, you can find instructions for installing it [here](https://opendatahub.io/docs/quick-installation/). The default settings for the Open Data Hub Operator will suffice.
 
 ### NFD and GPU Operators
 


### PR DESCRIPTION
## Description

The https://opendatahub.io website structure has been updated, and has broken some links.

## How Has This Been Tested?

I've checked the link works, and it's the only link to https://opendatahub.io in the repository.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
