### PR TITLE
use opendatahub ray operator image to bypass dockerhub rate limiting

### DIFF
--- a/ray/operator/base/kustomization.yaml
+++ b/ray/operator/base/kustomization.yaml
@@ -25,6 +25,6 @@ resources:
 
 images:
 - name: kuberay/operator
-  newName: kuberay/operator
+  newName: quay.io/opendatahub/kuberay-operator
   newTag: v0.3.0
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
closes: #47 
