### PR TITLE
adding makefile to deploy into openshift

### DIFF
--- a/.mk/observability.mk
+++ b/.mk/observability.mk
@@ -1,0 +1,9 @@
+##@ observability
+
+.PHONY: opendatahub-observability
+opendatahub-observability: ## Observability endpoints 
+	@export URL=`kubectl get route prometheus-portal -n opendatahub -o jsonpath="http://{.spec.host}"`; \
+	echo -e "\n ==>> OpenDataHub Infra. Prometheus: $$URL\n";
+	@export URL=`kubectl get route odh-model-monitoring -n opendatahub -o jsonpath="http://{.spec.host}"`; \
+	echo -e "\n ==>> OpenDataHub Model Prometheus: $$URL\n";
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,104 @@
+export PATH:=$(GOBIN):$(PATH)
+
+SHELL := /bin/bash
+OCI_RUNTIME ?= $(shell which podman  || which docker)
+CMD_DIR=./cmd/
+
+.DEFAULT_GOAL := help
+
+FORCE: ;
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ all-in-one
+.PHONY: all-in-one # All-In-One
+all-in-one: ## Install distributed AI platform  
+	@echo -e "\n==> Installing Everything needed for distributed AI platform on OpenShift cluster \n"
+	-make delete-codeflare delete-ndf-operator delete-nvidia-operator delete-codeflare-operator delete-opendatahub-operator
+	make install-opendatahub-operator install-codeflare-operator install-ndf-operator install-nvidia-operator deploy-codeflare
+	make opendatahub-dashboard
+	@echo -e "\n==> Done (Deploy everything)\n" 
+
+.PHONY: opendatahub-dashboard
+opendatahub-dashboard:
+	echo -e "\n\n =====>>>>> Waiting for OpenDataHub dashboard to be ready\n";
+	@while [[ -z $$(oc rollout -n opendatahub status deployment odh-dashboard --timeout=600s) ]]; do echo "."; sleep 5; done
+	@export URL=`oc get route odh-dashboard -n opendatahub -o jsonpath="http://{.spec.host}"`; \
+	echo -e "\n\n =====>>>>> Access OpenDataHub using: $$URL\n";
+
+##@ general
+.PHONY: install-opendatahub-operator
+install-opendatahub-operator: ## Install OpenDataHub operator
+	@echo -e "\n==> Installing OpenDataHub Operator \n"
+	-oc create ns opendatahub
+	oc create -f contrib/configuration/opendatahub-operator-subscription.yaml
+
+.PHONY: delete-opendatahub-operator
+delete-opendatahub-operator: ## Delete OpenDataHub operator
+	@echo -e "\n==> Deleting OpenDataHub Operator \n"
+	-oc delete subscription opendatahub-operator -n openshift-operators
+	-export CLUSTER_SERVICE_VERSION=`oc get clusterserviceversion -n openshift-operators -l operators.coreos.com/opendatahub-operator.openshift-operators -o custom-columns=:metadata.name`; \
+	oc delete clusterserviceversion $$CLUSTER_SERVICE_VERSION -n openshift-operators
+
+.PHONY: install-codeflare-operator
+install-codeflare-operator: ## Install CodeFlare operator
+	@echo -e "\n==> Installing CodeFlare Operator \n"
+	oc create -f contrib/configuration/codeflare-operator-subscription.yaml
+
+.PHONY: delete-codeflare-operator
+delete-codeflare-operator: ## Delete CodeFlare operator
+	@echo -e "\n==> Deleting CodeFlare Operator \n"
+	-oc delete subscription codeflare-operator -n openshift-operators
+	-export CLUSTER_SERVICE_VERSION=`oc get clusterserviceversion -n openshift-operators -l operators.coreos.com/codeflare-operator.openshift-operators -o custom-columns=:metadata.name`; \
+	oc delete clusterserviceversion $$CLUSTER_SERVICE_VERSION -n openshift-operators
+
+##@ CodeFlare
+
+.PHONY: deploy-codeflare
+deploy-codeflare: ## Deploy CodeFlare
+	@echo -e "\n==> Deploying CodeFlare \n"
+	-oc create ns opendatahub
+	@while [[ -z $$(oc get customresourcedefinition kfdefs.kfdef.apps.kubeflow.org) ]]; do echo "."; sleep 10; done
+	oc apply -f https://raw.githubusercontent.com/opendatahub-io/odh-manifests/master/kfdef/odh-core.yaml -n opendatahub
+	oc apply -f https://raw.githubusercontent.com/opendatahub-io/distributed-workloads/main/codeflare-stack-kfdef.yaml -n opendatahub
+
+.PHONY: delete-codeflare
+delete-codeflare: ## Delete CodeFlare
+	@echo -e "\n==> Deleteing CodeFlare \n"
+	-oc delete -f https://raw.githubusercontent.com/opendatahub-io/odh-manifests/master/kfdef/odh-core.yaml -n opendatahub
+	-oc delete -f https://raw.githubusercontent.com/opendatahub-io/distributed-workloads/main/codeflare-stack-kfdef.yaml -n opendatahub
+	-oc delete ns opendatahub
+
+##@ GPU Support
+
+.PHONY: install-ndf-operator
+install-ndf-operator: ## Install NDF operator ( Node Feature Discovery )
+	@echo -e "\n==> Installing NDF Operator \n"
+	-oc create ns openshift-nfd
+	oc create -f contrib/configuration/ndf-operator-subscription.yaml
+
+.PHONY: delete-ndf-operator
+delete-ndf-operator: ## Delete NDF operator
+	@echo -e "\n==> Deleting NDF Operator \n"
+	-oc delete subscription nfd -n openshift-nfd
+	-export CLUSTER_SERVICE_VERSION=`oc get clusterserviceversion -n openshift-nfd -l operators.coreos.com/nfd.openshift-nfd -o custom-columns=:metadata.name`; \
+	oc delete clusterserviceversion $$CLUSTER_SERVICE_VERSION -n openshift-nfd
+	-oc delete ns openshift-nfd
+
+.PHONY: install-nvidia-operator
+install-nvidia-operator: ## Install nvidia operator
+	@echo -e "\n==> Installing nvidia Operator \n"
+	-oc create ns nvidia-gpu-operator
+	oc create -f contrib/configuration/nvidia-operator-subscription.yaml
+
+.PHONY: delete-nvidia-operator
+delete-nvidia-operator: ## Delete nvidia operator
+	@echo -e "\n==> Deleting nvidia Operator \n"
+	-oc delete subscription gpu-operator-certified -n nvidia-gpu-operator
+	-export CLUSTER_SERVICE_VERSION=`oc get clusterserviceversion -n nvidia-gpu-operator -l operators.coreos.com/gpu-operator-certified.nvidia-gpu-operator -o custom-columns=:metadata.name`; \
+	oc delete clusterserviceversion $$CLUSTER_SERVICE_VERSION -n nvidia-gpu-operator
+	-oc delete ns nvidia-gpu-operator
+
+include .mk/observability.mk

--- a/Quick-Start.md
+++ b/Quick-Start.md
@@ -6,6 +6,17 @@ The CodeFlare-SDK was built to make managing distributed compute infrastructure 
 
 This stack integrates well with [Open Data Hub](https://opendatahub.io/), and helps to bring batch workloads, jobs, and queuing to the Data Science platform.
 
+## Automatic deployment
+
+As a quick alternative to the following manual deployment steps an automaic *makefile* script can be used to deploy the CodeFlare stack. This script also deploys the prerequisite operators and the entire CodeFlare stack up to the step [Submit your first job](#submit-your-first-job).
+To use this script, clone the repo and execute:
+
+```bash
+make all-in-one
+```
+
+> Note : Execute ```make help``` to list additional available operations.
+
 ## Prerequisites
 
 ### Resources

--- a/contrib/configuration/codeflare-operator-subscription.yaml
+++ b/contrib/configuration/codeflare-operator-subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: codeflare-operator
+  labels:
+    operators.coreos.com/codeflare-operator.openshift-operators: ''
+  namespace: openshift-operators
+spec:
+  channel: alpha
+  name: codeflare-operator
+  installPlanApproval: Automatic
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/contrib/configuration/ndf-operator-subscription.yaml
+++ b/contrib/configuration/ndf-operator-subscription.yaml
@@ -1,0 +1,19 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: nfd
+  namespace: openshift-nfd
+---  
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nfd
+  labels:
+    operators.coreos.com/nfd.openshift-nfd: ''
+  namespace: openshift-nfd
+spec:
+  channel: stable
+  name: nfd
+  installPlanApproval: Automatic
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/contrib/configuration/nvidia-operator-subscription.yaml
+++ b/contrib/configuration/nvidia-operator-subscription.yaml
@@ -1,0 +1,22 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: gpu-operator-certified
+  namespace: nvidia-gpu-operator
+spec:
+  targetNamespaces:
+  - opendatahub
+--- 
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: gpu-operator-certified
+  labels:
+    operators.coreos.com/gpu-operator-certified.nvidia-gpu-operator: ''
+  namespace: nvidia-gpu-operator
+spec:
+  channel: v23.3
+  name: gpu-operator-certified
+  installPlanApproval: Automatic
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/contrib/configuration/opendatahub-operator-subscription.yaml
+++ b/contrib/configuration/opendatahub-operator-subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opendatahub-operator
+  labels:
+    operators.coreos.com/opendatahub-operator.openshift-operators: ''
+  namespace: openshift-operators
+spec:
+  channel: rolling
+  name: opendatahub-operator
+  installPlanApproval: Automatic
+  source: community-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
This PR adds a Makefile and the needed configuration files to quickly deploy the distribution stack into openshift. The Makefile includes `all-in-one` target to deploy all required components in a single command.

## Description
```
Usage:
  make <target>
  help                  Display this help.

all-in-one
  all-in-one            Install distributed AI platform

general
  install-opendatahub-operator  Install OpenDataHub operator
  delete-opendatahub-operator  Delete OpenDataHub operator
  install-codeflare-operator  Install CodeFlare operator
  delete-codeflare-operator  Delete CodeFlare operator

CodeFlare
  deploy-codeflare      Deploy CodeFlare
  delete-codeflare      Delete CodeFlare

GPU Support
  install-ndf-operator  Install NDF operator ( Node Feature Discovery )
  delete-ndf-operator   Delete NDF operator
  install-nvidia-operator  Install nvidia operator
  delete-nvidia-operator  Delete nvidia operator

observability
  opendatahub-observability  Observability endpoints
```

## How Has This Been Tested?
This was tested locally against OCP cluster in AWS ( using RH developer account )
For additional tests, this PR can be executed against different deployment flavors of OCP. `make all-in-one` and `make opendatahub-observability` should cover the complete set of operations. 

## Merge criteria:
N/A

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added to the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
