### PR TITLE
Add documentation on installing custom images

### DIFF
--- a/Quick-Start.md
+++ b/Quick-Start.md
@@ -21,7 +21,7 @@ Total:
 Ray:
     CPU: 100m
     Memory: 512Mi
-MCAD
+MCAD:
     cpu: 2000m
     memory: 2Gi
 InstaScale:
@@ -78,6 +78,20 @@ At this point you should be able to go to your notebook spawner page and select 
 
 You can access the spawner page through the Open Data Hub dashboard. The default route should be `https://odh-dashboard-<your ODH namespace>.apps.<your cluster's uri>`. Once you are on your dashboard, you can select "Launch application" on the Jupyter application. This will take you to your notebook spawner page.
 
+### [Optional] - Install custom images of MCAD and/or InstaScale
+After adding the MCAD and InstaScale objects, the simplest way to update their versions is by replacing the `controllerImage` value in their Custom Resource Definitions (CRDs) with the path to your custom image. This image might be stored in a registry, such as quay.io. To help you build and push your custom image to a registry, both the [MCAD](https://github.com/project-codeflare/multi-cluster-app-dispatcher) and [InstaScale](https://github.com/project-codeflare/instascale) repositories provide `make` commands to achieve this.
+
+Replacing the value of the `controllerImage` may be done manually or by running the following command:
+
+#### OpenShift
+```
+oc patch instascale instascale -n opendatahub --type='json' -p='[{"op": "replace", "path": "/spec/controllerImage", "value": "<PathToYourCustomImage>"}]'
+```
+
+#### Kubernetes
+```
+kubectl patch instascale instascale -n opendatahub --type='json' -p='[{"op": "replace", "path": "/spec/controllerImage", "value": "<PathToYourCustomImage>"}]'
+```
 
 ### Using an Openshift Dedicated or ROSA Cluster
 If you are using an Openshift Dedicated or ROSA Cluster you will need to create a secret in the opendatahub namespace containing your ocm token. You can find your token [here](https://console.redhat.com/openshift/token). Navigate to Workloads -> secrets in the Openshift Console. Click Create and choose a key/value secret. Secret name: instascale-ocm-secret, Key: token, Value: < ocm token > and click create.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Artifacts for installing the Distributed Workloads stack as part of ODH
 
 Distributed Workloads is a simple, user-friendly abstraction for scaling,
 queuing and resource management of distributed AI/ML and Python workloads.
-It consists of three components:
+It consists of four components:
 
 * [CodeFlare SDK](https://github.com/project-codeflare/codeflare-sdk) to define and control remote distributed compute jobs and infrastructure with any Python based environment
 * [Multi-Cluster Application Dispatcher (MCAD)](https://github.com/project-codeflare/multi-cluster-app-dispatcher) for management of batch jobs


### PR DESCRIPTION
Closes #68 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added documentation to the Quick-Start on how to install custom images of MCAD and/or InstaScale to your OpenShift or Kubernetes cluster.
- Provided commands which may be used to efficiently replace the `controllerImage` value in a CRD to the path to the custom image.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Commands tested on OpenShift OSD cluster.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

## Additional Notes:
I added this documentation in this repository as it can then be added in the [CodeFlare-Operator wiki](https://github.com/project-codeflare/codeflare-operator/wiki/CodeFlare-Operator-Installation#codeflare-operator-installation). Opened to thoughts on this?
