### PR TITLE
Fix Ray generated configmap name

### DIFF
--- a/ray/operator/base/kustomization.yaml
+++ b/ray/operator/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 configMapGenerator:
-- name: codeflare-stack-config
+- name: ray-config
   envs:
     - params.env
 configurations:
@@ -12,7 +12,7 @@ vars:
 - name: namespace
   objref:
     kind: ConfigMap
-    name: codeflare-stack-config
+    name: ray-config
     apiVersion: v1
   fieldref:
     fieldpath: data.namespace


### PR DESCRIPTION
We have accidentally been using the same configmap name for both CodeFlare and Ray. This hadn't been a problem with the old operator, but with the new operator, when users attempt to deploy only CodeFlare and not Ray (or the other way around), the ODH operator ends up in a reconcile loop where
CodeFlare creates cm -> Ray manifests say cm should be deleted, so operator deletes cm -> CodeFlare finds that the cm doesn't exist, so it creates again

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
