### PR TITLE
Defer retrieving GetRayJobId in test

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,7 +3,7 @@ module github.com/opendatahub-io/distributed-workloads/tests/new-tests
 require (
 	github.com/onsi/gomega v1.27.8
 	github.com/openshift/api v0.0.0-20230718161610-2a3e8b481cec
-	github.com/project-codeflare/codeflare-operator v0.1.1-0.20230817124305-be0dd48b43b4
+	github.com/project-codeflare/codeflare-operator v0.1.1-0.20230823091637-6f7d6b1194dd
 	github.com/ray-project/kuberay/ray-operator v0.0.0-20230807232553-238cb4e945b6
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -87,8 +87,8 @@ github.com/openshift/client-go v0.0.0-20230718165156-6014fb98e86a h1:ZKewwwEIURD
 github.com/openshift/client-go v0.0.0-20230718165156-6014fb98e86a/go.mod h1:EjhPQjEm8HM3GThz5ywNGLEec1P1IjTn08kwzdvupvA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/project-codeflare/codeflare-operator v0.1.1-0.20230817124305-be0dd48b43b4 h1:zEkjcrKhY3XC3TNGWFg6QlFZuC2BWfRufAvv+xrVFb8=
-github.com/project-codeflare/codeflare-operator v0.1.1-0.20230817124305-be0dd48b43b4/go.mod h1:BtKefU7oi9bb9M2flQXERqjX3KNTVe9uWkD0C2wdHjM=
+github.com/project-codeflare/codeflare-operator v0.1.1-0.20230823091637-6f7d6b1194dd h1:c1CrFGX9pRPm4vTx5U+A5ptY51gKEM3hhcrPBdEN7bk=
+github.com/project-codeflare/codeflare-operator v0.1.1-0.20230823091637-6f7d6b1194dd/go.mod h1:BtKefU7oi9bb9M2flQXERqjX3KNTVe9uWkD0C2wdHjM=
 github.com/project-codeflare/multi-cluster-app-dispatcher v1.33.0 h1:6a+MnxcFSlheC7RIPGg3s/QCt5+7dD8mJKwdpST7i70=
 github.com/project-codeflare/multi-cluster-app-dispatcher v1.33.0/go.mod h1:0J0BDSaIN5lvlmgw+32FcMqe8SflXHtHByUbHmPl4w8=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/tests/integration/ray_test.go
+++ b/tests/integration/ray_test.go
@@ -112,7 +112,7 @@ func TestRayCluster(t *testing.T) {
 	dashboardHostname := dashboard.Status.Ingress[0].Host
 
 	rayClient := support.NewRayClusterClient(url.URL{Scheme: "http", Host: dashboardHostname})
-	defer support.WriteRayJobAPILogs(test, rayClient, support.GetRayJobId(test, rayJob.Namespace, rayJob.Name))
+	defer support.WriteRayJobLogs(test, rayClient, rayJob.Namespace, rayJob.Name)
 
 	test.T().Logf("Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
 	test.Eventually(support.RayJob(test, rayJob.Namespace, rayJob.Name), support.TestTimeoutLong).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
GetRayJobId call needs to be deferred to make sure that job id is stored by KubeRay cluster.

## Description
<!--- Describe your changes in detail -->
TestRayCluster test was failing on log storage line. Log storage function was deferred, however its arguments are resolved in realtime, causing GetRayJobId to be resolved before KubeRay operator had a chance to store job id in RayJob CR. 

Moving the whole log storage line into separate function makes sure that RayJob CR is fully initialized.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
