### PR TITLE
Makefile: Add commands to install latest dev CodeFlare operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CMD_DIR=./cmd/
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
+TMPDIR ?= /tmp
 
 ## Tool Binaries
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
@@ -66,6 +67,18 @@ delete-codeflare-operator: ## Delete CodeFlare operator
 	-oc delete subscription codeflare-operator -n openshift-operators
 	-export CLUSTER_SERVICE_VERSION=`oc get clusterserviceversion -n openshift-operators -l operators.coreos.com/codeflare-operator.openshift-operators -o custom-columns=:metadata.name`; \
 	oc delete clusterserviceversion $$CLUSTER_SERVICE_VERSION -n openshift-operators
+
+.PHONY: install-codeflare-operator-from-github
+install-codeflare-operator-from-github: ## Install CodeFlare operator from main branch on GitHub
+	@echo -e "\n==> Installing CodeFlare Operator from main branch on GitHub \n"
+	test -d $(TMPDIR)/codeflare || git clone https://github.com/project-codeflare/codeflare-operator.git $(TMPDIR)/codeflare
+	VERSION=dev make deploy -C $(TMPDIR)/codeflare
+
+.PHONY: delete-codeflare-operator-from-github
+delete-codeflare-operator-from-github: ## Delete CodeFlare operator from main branch on GitHub
+	@echo -e "\n==> Deleting CodeFlare Operator from main branch on GitHub \n"
+	test -d $(TMPDIR)/codeflare || git clone https://github.com/project-codeflare/codeflare-operator.git $(TMPDIR)/codeflare
+	make undeploy -C $(TMPDIR)/codeflare
 
 ##@ CodeFlare
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add Makefile commands which allow installing CodeFlare operator from latest main branch.
This will come handy for ODH PR checks - making sure that PR is running against latest state of CodeFlare operator.

## Description
<!--- Describe your changes in detail -->
Commands clone main branch of CodeFlare operator repository and invoke `make deploy` to deploy latest operator.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
