### PR TITLE
Makefile: Install ODH 2.x operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,15 +86,13 @@ delete-codeflare-operator-from-github: ## Delete CodeFlare operator from main br
 deploy-codeflare: ## Deploy CodeFlare
 	@echo -e "\n==> Deploying CodeFlare \n"
 	-oc create ns opendatahub
-	@while [[ -z $$(oc get customresourcedefinition kfdefs.kfdef.apps.kubeflow.org) ]]; do echo "."; sleep 10; done
-	oc apply -f https://raw.githubusercontent.com/opendatahub-io/odh-manifests/master/kfdef/odh-core.yaml -n opendatahub
-	oc apply -f https://raw.githubusercontent.com/opendatahub-io/distributed-workloads/main/codeflare-stack-kfdef.yaml -n opendatahub
+	@while [[ -z $$(oc get customresourcedefinition datascienceclusters.datasciencecluster.opendatahub.io) ]]; do echo "."; sleep 10; done
+	oc apply -f https://raw.githubusercontent.com/opendatahub-io/distributed-workloads/main/codeflare-dsc.yaml -n opendatahub
 
 .PHONY: delete-codeflare
 delete-codeflare: ## Delete CodeFlare
 	@echo -e "\n==> Deleting CodeFlare \n"
-	-oc delete -f https://raw.githubusercontent.com/opendatahub-io/odh-manifests/master/kfdef/odh-core.yaml -n opendatahub
-	-oc delete -f https://raw.githubusercontent.com/opendatahub-io/distributed-workloads/main/codeflare-stack-kfdef.yaml -n opendatahub
+	-oc delete -f https://raw.githubusercontent.com/opendatahub-io/distributed-workloads/main/codeflare-dsc.yaml -n opendatahub
 	-oc delete ns opendatahub
 
 .PHONY: deploy-codeflare-from-filesystem

--- a/contrib/configuration/basic-dsc.yaml
+++ b/contrib/configuration/basic-dsc.yaml
@@ -1,0 +1,26 @@
+apiVersion: datasciencecluster.opendatahub.io/v1alpha1
+kind: DataScienceCluster
+metadata:
+  labels:
+    app.kubernetes.io/created-by: opendatahub-operator
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: datasciencecluster
+    app.kubernetes.io/part-of: opendatahub-operator
+  name: example-dsc
+spec:
+  components:
+    codeflare:
+      enabled: false
+    dashboard:
+      enabled: true
+    datasciencepipelines:
+      enabled: false
+    kserve:
+      enabled: false
+    modelmeshserving:
+      enabled: false
+    ray:
+      enabled: false
+    workbenches:
+      enabled: true

--- a/contrib/configuration/opendatahub-operator-subscription.yaml
+++ b/contrib/configuration/opendatahub-operator-subscription.yaml
@@ -6,7 +6,7 @@ metadata:
     operators.coreos.com/opendatahub-operator.openshift-operators: ''
   namespace: openshift-operators
 spec:
-  channel: rolling
+  channel: fast
   name: opendatahub-operator
   installPlanApproval: Automatic
   source: community-operators


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adjusting Makefile commands to deploy ODH 2.x operator.
Fixes https://github.com/opendatahub-io/distributed-workloads/issues/121

## Description
<!--- Describe your changes in detail -->
Use ODH 2.x operator.
Added `contrib/configuration/basic-dsc.yaml`, this DSC CR will be used by OpenShift CI. Intention is to deploy basic ODH components using DSC CR, the rest is deployed manually to use latest resources (as done now).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
