### PR TITLE
Bind Ray ClusterRole to the new operator ServiceAccount

### DIFF
--- a/codeflare-stack/rbac/mcad-controller-ray-clusterrolebinding.yaml
+++ b/codeflare-stack/rbac/mcad-controller-ray-clusterrolebinding.yaml
@@ -4,8 +4,8 @@ metadata:
   name: mcad-controller-ray-clusterrolebinding
 subjects:
   - kind: ServiceAccount
-    name: mcad-controller-mcad
-    namespace: $(namespace)
+    name: codeflare-operator-controller-manager
+    namespace: openshift-operators
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Fix a missing update from #125, to bind the Ray ClusterRole to the CodeFlare operator ServiceAccount.

It'll be simplified once project-codeflare/multi-cluster-app-dispatcher#635 is implemented.