### PR TITLE
Update to 1.0.0-rc.0 Ray Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Integration of this stack into the Open Data Hub is owned by the Distributed Wor
 | Multi-Cluster App Dispatcher | v1.35.0 |
 | CodeFlare-SDK                | v0.8.0  |
 | InstaScale                   | v0.0.9  |
-| KubeRay                      | v0.6.0  |
+| KubeRay                      | v1.0.0-rc.0  |
 <!-- Compatibility Matrix end -->
 
 ## Quick Start

--- a/ray/operator/base/params.env
+++ b/ray/operator/base/params.env
@@ -1,2 +1,2 @@
 namespace=opendatahub
-odh-kuberay-operator-controller-image=quay.io/kuberay/operator:v0.6.0
+odh-kuberay-operator-controller-image=quay.io/kuberay/operator:v1.0.0-rc.0

--- a/ray/operator/crd/bases/ray.io_rayclusters.yaml
+++ b/ray/operator/crd/bases/ray.io_rayclusters.yaml
@@ -6074,8 +6074,8 @@ spec:
                   type: string
                 type: object
               rayVersion:
-                description: RayVersion is the version of ray being used. This determines
-                  the autoscaler's image version.
+                description: RayVersion is used to determine the command for the Kubernetes
+                  Job managed by RayJob
                 type: string
               workerGroupSpecs:
                 description: WorkerGroupSpecs are the specs for the worker pods

--- a/ray/operator/crd/bases/ray.io_rayjobs.yaml
+++ b/ray/operator/crd/bases/ray.io_rayjobs.yaml
@@ -44,6 +44,18 @@ spec:
                 description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
                   Important: Run "make" to regenerate code af'
                 type: string
+              entrypointNumCpus:
+                description: EntrypointNumCpus specifies the number of cpus to reserve
+                  for the entrypoint command.
+                type: number
+              entrypointNumGpus:
+                description: EntrypointNumGpus specifies the number of gpus to reserve
+                  for the entrypoint command.
+                type: number
+              entrypointResources:
+                description: EntrypointResources specifies the custom resources and
+                  quantities to reserve for the entrypoint comm
+                type: string
               jobId:
                 description: If jobId is not set, a new jobId will be auto-generated.
                 type: string
@@ -6330,8 +6342,8 @@ spec:
                       type: string
                     type: object
                   rayVersion:
-                    description: RayVersion is the version of ray being used. This
-                      determines the autoscaler's image version.
+                    description: RayVersion is used to determine the command for the
+                      Kubernetes Job managed by RayJob
                     type: string
                   workerGroupSpecs:
                     description: WorkerGroupSpecs are the specs for the worker pods
@@ -12090,7 +12102,12 @@ spec:
                 - headGroupSpec
                 type: object
               runtimeEnv:
-                description: RuntimeEnv is base64 encoded.
+                description: RuntimeEnv is base64 encoded. This field is deprecated,
+                  please use RuntimeEnvYAML instead.
+                type: string
+              runtimeEnvYAML:
+                description: RuntimeEnvYAML represents the runtime environment configuration
+                  provided as a multi-line YAML string
                 type: string
               shutdownAfterJobFinishes:
                 description: ShutdownAfterJobFinishes will determine whether to delete

--- a/ray/operator/crd/bases/ray.io_rayservices.yaml
+++ b/ray/operator/crd/bases/ray.io_rayservices.yaml
@@ -6316,8 +6316,8 @@ spec:
                       type: string
                     type: object
                   rayVersion:
-                    description: RayVersion is the version of ray being used. This
-                      determines the autoscaler's image version.
+                    description: RayVersion is used to determine the command for the
+                      Kubernetes Job managed by RayJob
                     type: string
                   workerGroupSpecs:
                     description: WorkerGroupSpecs are the specs for the worker pods


### PR DESCRIPTION
This is a test PR to see if the latest KubeRay operator candidate will work with CodeFlare
This addresses issue https://github.com/opendatahub-io/distributed-workloads/issues/135

## Description
- Updated the Operator image to the 1.0.0-rc.0
- Updated the Readme to reflect the version change
- Updated the crds for the latest changes with KubeRay Operator

## How Has This Been Tested?
Testing now by deploying with CodeFlare Notebooks - looking good.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
