### PR TITLE
Add info on GPU hardware discovery and updates to quickstarts

### DIFF
--- a/Quick-Start-ODH-V2.md
+++ b/Quick-Start-ODH-V2.md
@@ -6,6 +6,17 @@ The CodeFlare-SDK was built to make managing distributed compute infrastructure 
 
 This stack integrates well with [Open Data Hub](https://opendatahub.io/), and helps to bring batch workloads, jobs, and queuing to the Data Science platform.
 
+## Automatic deployment
+
+As a quick alternative to the following manual deployment steps an automatic *makefile* script can be used to deploy the CodeFlare stack. This script also deploys the prerequisite operators and the entire CodeFlare stack up to the step [Using an Openshift Dedicated or ROSA Cluster](#using-an-openshift-dedicated-or-rosa-cluster).
+To use this script, clone the repo and execute:
+
+```bash
+make all-in-one
+```
+
+> Note : Execute ```make help``` to list additional available operations.
+
 ## Prerequisites
 
 ### Resources
@@ -47,6 +58,8 @@ suffice.
 ### NFD and GPU Operators
 
 If you want to run GPU enabled workloads, you will need to install the [Node Feature Discovery Operator](https://github.com/openshift/cluster-nfd-operator) and the [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator) from the OperatorHub. For instructions on how to install and configure these operators, we recommend [this guide](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/openshift/steps-overview.html#high-level-steps).
+
+In order for your OpenShift cluster to discover GPU hardware a ClusterPolicy CR must be created. For more information, this can be done by following the instructions [here](https://docs.nvidia.com/datacenter/cloud-native/openshift/23.6.1/install-gpu-ocp.html#create-the-clusterpolicy-instance). The defaults will suffice.
 
 ## Creating K8s resources
 

--- a/Quick-Start.md
+++ b/Quick-Start.md
@@ -6,17 +6,6 @@ The CodeFlare-SDK was built to make managing distributed compute infrastructure 
 
 This stack integrates well with [Open Data Hub](https://opendatahub.io/), and helps to bring batch workloads, jobs, and queuing to the Data Science platform.
 
-## Automatic deployment
-
-As a quick alternative to the following manual deployment steps an automaic *makefile* script can be used to deploy the CodeFlare stack. This script also deploys the prerequisite operators and the entire CodeFlare stack up to the step [Submit your first job](#submit-your-first-job).
-To use this script, clone the repo and execute:
-
-```bash
-make all-in-one
-```
-
-> Note : Execute ```make help``` to list additional available operations.
-
 ## Prerequisites
 
 ### Red Hat OpenShift
@@ -61,6 +50,8 @@ The CodeFlare operator must be installed from the OperatorHub on your OpenShift 
 ### NFD and GPU Operators
 
 If you want to run GPU enabled workloads, you will need to install the [Node Feature Discovery Operator](https://github.com/openshift/cluster-nfd-operator) and the [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator) from the OperatorHub. For instructions on how to install and configure these operators, we recommend [this guide](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/openshift/steps-overview.html#high-level-steps).
+
+In order for your OpenShift cluster to discover GPU hardware a ClusterPolicy CR must be created. For more information, this can be done by following the instructions [here](https://docs.nvidia.com/datacenter/cloud-native/openshift/23.6.1/install-gpu-ocp.html#create-the-clusterpolicy-instance). The defaults will suffice.
 
 
 ## Creating K8s resources


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #137 

## Description
<!--- Describe your changes in detail -->
- Added info on GPU hardware discovery to both quickstarts.
- Previously the `all-in-one` make target has been updated to work for ODH v2.*. I moved this information from quickstartV1 to quickstartV2.
- **[Question]** Should I bring back the `all-in-one` make target specific to ODH v1?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual Test

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
