### PR TITLE
Fix contextDir and sourcePath for ODH DSC used in PR checks

### DIFF
--- a/contrib/configuration/basic-dsc.yaml
+++ b/contrib/configuration/basic-dsc.yaml
@@ -14,6 +14,8 @@ spec:
       devFlags:
         manifests:
           - uri: '<DW PR tarball URI>'
+            contextDir: 'codeflare-stack'
+            sourcePath: 'base'
       managementState: Managed
     dashboard:
       managementState: Managed
@@ -27,6 +29,8 @@ spec:
       devFlags:
         manifests:
           - uri: '<DW PR tarball URI>'
+            contextDir: 'ray'
+            sourcePath: 'operator/base'
       managementState: Managed
     workbenches:
       managementState: Managed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix contextDir and sourcePath for ODH DSC used in PR checks

## Description
<!--- Describe your changes in detail -->
contextDir and sourcePath wasn't configured properly, causing PR check to leverage default manifest files instead of files from PR check.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
