### PR TITLE
Add Routes to Ray cluster role

### DIFF
--- a/codeflare-stack/rbac/mcad-controller-ray-clusterrole.yaml
+++ b/codeflare-stack/rbac/mcad-controller-ray-clusterrole.yaml
@@ -17,3 +17,15 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
This PR follows up project-codeflare/codeflare-operator#316, and adds permissions on Routes, that's currently required by the SDK to expose the dashboard endpoints of provisioned Ray clusters.