### PR TITLE
Use busybox from quay.io

### DIFF
--- a/tests/integration/ray_test.go
+++ b/tests/integration/ray_test.go
@@ -319,7 +319,7 @@ func createRayCluster(test support.Test, namespace string, mnist *corev1.ConfigM
 							InitContainers: []corev1.Container{
 								{
 									Name:    "init-myservice",
-									Image:   "busybox:1.28",
+									Image:   "quay.io/project-codeflare/busybox:1.36",
 									Command: []string{"sh", "-c", "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"},
 								},
 							},


### PR DESCRIPTION
Use busybox from quay.io instead of from Docker hub. Version should stay the same.