### PR TITLE
Copy test model from image rather than downloading it

### DIFF
--- a/model-images/bloom560m/Dockerfile
+++ b/model-images/bloom560m/Dockerfile
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi9:9.4 as builder
+WORKDIR /
+RUN dnf install -y git-lfs
+
+RUN git lfs install
+RUN git clone https://huggingface.co/bigscience/bloom-560m
+RUN rm -r bloom-560m/onnx
+RUN rm -r bloom-560m/.git
+
+FROM registry.access.redhat.com/ubi9:9.4
+WORKDIR /
+
+COPY --from=builder /bloom-560m /models/bloom-560m
+

--- a/tests/kfto/config.json
+++ b/tests/kfto/config.json
@@ -1,5 +1,5 @@
 {
-    "model_name_or_path": "bigscience/bloom-560m",
+    "model_name_or_path": "/tmp/model/bloom-560m",
     "training_data_path": "/etc/config/twitter_complaints_small.json",
     "output_dir": "/tmp/out",
     "num_train_epochs": 1.0,
@@ -19,5 +19,5 @@
     "use_flash_attn": false,
     "torch_dtype": "float32",
     "peft_method": "pt",
-    "tokenizer_name_or_path": "bigscience/bloom"
+    "tokenizer_name_or_path": "/tmp/model/bloom-560m"
 }

--- a/tests/kfto/environment.go
+++ b/tests/kfto/environment.go
@@ -23,10 +23,16 @@ import (
 const (
 	// The environment variable for FMS HF Tuning image to be tested
 	fmsHfTuningImageEnvVar = "FMS_HF_TUNING_IMAGE"
+	// The environment variable referring to image containing bloom-560m model
+	bloomModelImageEnvVar = "BLOOM_MODEL_IMAGE"
 )
 
 func GetFmsHfTuningImage() string {
-	return lookupEnvOrDefault(fmsHfTuningImageEnvVar, "quay.io/modh/fms-hf-tuning:b71215c3ae202eab9da1d347f52b89feb3d0378c")
+	return lookupEnvOrDefault(fmsHfTuningImageEnvVar, "quay.io/modh/fms-hf-tuning:d0bd35b0297c28b87ee6caa32d5966d77587591f")
+}
+
+func GetBloomModelImage() string {
+	return lookupEnvOrDefault(bloomModelImageEnvVar, "quay.io/ksuta/bloom-560m:0.0.1")
 }
 
 func lookupEnvOrDefault(key, value string) string {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change allows to run e2e tests in disconnected environment, once all required images are provided.
Also it saves bandwidth by using available image to get a large model.

Model image currently hosted on my own Quay account, can be moved to dedicated account if we will decide which one.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by running the e2e test.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
