### PR TITLE
Restart PyTorchJob on failure to prevent Workload termination

### DIFF
--- a/tests/kfto/core/kfto_kueue_sft_test.go
+++ b/tests/kfto/core/kfto_kueue_sft_test.go
@@ -180,7 +180,7 @@ func createPyTorchJob(test Test, namespace, localQueueName string, config corev1
 			PyTorchReplicaSpecs: map[kftov1.ReplicaType]*kftov1.ReplicaSpec{
 				"Master": {
 					Replicas:      Ptr(int32(1)),
-					RestartPolicy: "Never",
+					RestartPolicy: "OnFailure",
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							InitContainers: []corev1.Container{

--- a/tests/kfto/upgrade/kfto_kueue_sft_upgrade_test.go
+++ b/tests/kfto/upgrade/kfto_kueue_sft_upgrade_test.go
@@ -144,7 +144,7 @@ func createPyTorchJob(test Test, namespace, localQueueName string, config corev1
 			PyTorchReplicaSpecs: map[kftov1.ReplicaType]*kftov1.ReplicaSpec{
 				"Master": {
 					Replicas:      Ptr(int32(1)),
-					RestartPolicy: "Never",
+					RestartPolicy: "OnFailure",
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							InitContainers: []corev1.Container{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
By default Kueue terminates Workload which isn't ready in 5 minutes.
As PyTorchJob image is big then Kueue may terminate job workload before image is pulled, causing test to fail.
By setting RestartPolicy to `OnFailure` the Kueue will restart PyTorchJob if it fails, making sure that wokload is processed on second attempt if first attempt fails pulling image.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on a cluster without PyTorchJob image available on a node.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
