### PR TITLE
UBI9 Ray container image

### DIFF
--- a/examples/ray-finetune-llm-deepspeed/README.md
+++ b/examples/ray-finetune-llm-deepspeed/README.md
@@ -55,6 +55,8 @@ You can also setup [TensorBoard](https://github.com/tensorflow/tensorboard) to v
     ```console
     kubectl exec `kubectl get pod -l ray.io/node-type=head -o name` -- tensorboard --logdir /tmp/ray --bind_all --port 6006"
     ```
+    Note: You may need to install `tb-nightly` instead of `tensorboard` during the interim a version compatible with NumPy 2 is released.
+    See https://github.com/tensorflow/tensorboard/issues/6869.
 * Port-foward the TensorBoard UI endpoint:
     ```console
     kubectl port-forward `kubectl get pod -l ray.io/node-type=head -o name` 6006:6006

--- a/examples/ray-finetune-llm-deepspeed/ray_finetune_llm_deepspeed.ipynb
+++ b/examples/ray-finetune-llm-deepspeed/ray_finetune_llm_deepspeed.ipynb
@@ -69,7 +69,7 @@
     "    head_memory=128,\n",
     "    head_gpus=1,\n",
     "    num_gpus=1,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121-torch\",\n",
+    "    image=\"quay.io/rhoai/ray:2.23.0-py311-cu121-torch\",\n",
     "))"
    ]
   },

--- a/examples/ray-finetune-llm-deepspeed/ray_finetune_llm_deepspeed.ipynb
+++ b/examples/ray-finetune-llm-deepspeed/ray_finetune_llm_deepspeed.ipynb
@@ -69,7 +69,7 @@
     "    head_memory=128,\n",
     "    head_gpus=1,\n",
     "    num_gpus=1,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py311-cu121-torch\",\n",
+    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121-torch\",\n",
     "))"
    ]
   },

--- a/examples/ray-finetune-llm-deepspeed/requirements.txt
+++ b/examples/ray-finetune-llm-deepspeed/requirements.txt
@@ -3,8 +3,9 @@ awscliv2==2.3.0
 datasets==2.19.2
 deepspeed==0.14.3
 # Flash Attention 2 requires PyTorch to be installed first
-# See https://github.com/Dao-AILab/flash-attention/issues/246
-flash-attn==2.5.9.post1
+# See https://github.com/Dao-AILab/flash-attention/issues/453
+#flash-attn==2.5.9.post1
+https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.9.post1/flash_attn-2.5.9.post1+cu122torch2.3cxx11abiFALSE-cp311-cp311-linux_x86_64.whl
 peft==0.11.1
 ray[train]==2.23.0
 torch==2.3.1

--- a/examples/ray-finetune-llm-deepspeed/requirements.txt
+++ b/examples/ray-finetune-llm-deepspeed/requirements.txt
@@ -1,7 +1,7 @@
 accelerate==0.31.0
 awscliv2==2.3.0
 datasets==2.19.2
-deepspeed==0.14.3
+deepspeed==0.14.4
 # Flash Attention 2 requires PyTorch to be installed first
 # See https://github.com/Dao-AILab/flash-attention/issues/453
 #flash-attn==2.5.9.post1

--- a/examples/ray-finetune-llm-deepspeed/requirements.txt
+++ b/examples/ray-finetune-llm-deepspeed/requirements.txt
@@ -5,7 +5,7 @@ deepspeed==0.14.4
 # Flash Attention 2 requires PyTorch to be installed first
 # See https://github.com/Dao-AILab/flash-attention/issues/453
 #flash-attn==2.5.9.post1
-https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.9.post1/flash_attn-2.5.9.post1+cu122torch2.3cxx11abiFALSE-cp311-cp311-linux_x86_64.whl
+https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.9.post1/flash_attn-2.5.9.post1+cu122torch2.3cxx11abiFALSE-cp39-cp39-linux_x86_64.whl
 peft==0.11.1
 ray[train]==2.23.0
 torch==2.3.1

--- a/images/runtime/README.md
+++ b/images/runtime/README.md
@@ -1,0 +1,3 @@
+# Distributed Workloads Container Images
+
+Sources for the container images provided by Distributed Workloads in OpenShift AI.

--- a/images/runtime/examples/README.md
+++ b/images/runtime/examples/README.md
@@ -3,3 +3,43 @@
 > [!IMPORTANT]
 > These examples are provided for documentation purpose, on how to build custom container images for Distributed Workloads.
 > These container examples are not supported, not part of OpenShift AI.
+
+## Prerequisites
+
+You need to have Podman install on your local environment, to build and push these custom container images to your registry, so they can be used to run distributed workloads in OpenShift AI.
+
+## Build
+
+The container images can be built using Podman, e.g., for the `ray-torch` example:
+
+```
+export IMG=ray-torch
+cd $IMG
+podman build -t ${IMG} -f Dockerfile
+```
+
+You can then push that image to your container registry.
+Alternatively, you can use the [integrated OpenShift container registry](https://docs.openshift.com/container-platform/4.16/registry/index.html#registry-integrated-openshift-registry_registry-overview), by following these intructions:
+
+1. Expose the integrated container registry:
+    ```
+    oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
+    ```
+2. Wait for the route to the container registry to be admitted:
+    ```
+    oc wait -n openshift-image-registry route/default-route --for=jsonpath='{.status.ingress[0].conditions[0].status}'=True
+    ```
+3. Login to the container registry, e.g., with Podman:
+    ```
+    podman login -u $(oc whoami) -p $(oc whoami -t) $(oc registry info)
+    ```
+4. Push the image to the integrated container registry:
+    ```
+    podman tag ${IMG} $(oc registry info)/$(oc project -q)/${IMG}
+    podman push $(oc registry info)/$(oc project -q)/${IMG}
+    ```
+5. Retrieve the image repository for the tag you want, e.g.:
+    ```
+    oc get is ${IMG} -o jsonpath='{.status.tags[?(@.tag=="<TAG>")].items[0].dockerImageReference}'
+    ```
+6. You can now use that image repository in your notebook.

--- a/images/runtime/examples/README.md
+++ b/images/runtime/examples/README.md
@@ -1,0 +1,5 @@
+# Custom Container Image Examples
+
+> [!IMPORTANT]
+> These examples are provided for documentation purpose, on how to build custom container images for Distributed Workloads.
+> These container examples are not supported, not part of OpenShift AI.

--- a/images/runtime/examples/ray-torch/Dockerfile
+++ b/images/runtime/examples/ray-torch/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/rhoai/ray:2.23.0-py311-cu121
+
+RUN python3 -m pip install --no-cache-dir -U pip \
+    torch==2.3.1

--- a/images/runtime/examples/ray-torch/Dockerfile
+++ b/images/runtime/examples/ray-torch/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/rhoai/ray:2.23.0-py311-cu121
+FROM quay.io/rhoai/ray:2.23.0-py39-cu121
 
 RUN python3 -m pip install --no-cache-dir -U pip \
     torch==2.3.1

--- a/images/runtime/ray/Dockerfile
+++ b/images/runtime/ray/Dockerfile
@@ -1,5 +1,127 @@
-FROM rayproject/ray:2.23.0-py39-cu121
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
-# Flash Attention 2 requires PyTorch at installation time
-RUN pip install --no-cache-dir -U pip \
-    torch==2.3.1
+LABEL name="ray-ubi9-py311-cu121" \
+      summary="CUDA 12.1 Python 3.11 image based on UBI9 for Ray" \
+      description="CUDA 12.1 Python 3.11 image based on UBI9 for Ray" \
+      io.k8s.display-name="CUDA 12.1 Python 3.11 base image for Ray" \
+      io.k8s.description="CUDA 12.1 Python 3.11 image based on UBI9 for Ray" \
+      authoritative-source-url="https://github.com/opendatahub-io/distributed-workloads"
+
+# Install CUDA base from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/base/Dockerfile
+USER 0
+WORKDIR /opt/app-root/bin
+
+ENV NVARCH x86_64
+ENV NVIDIA_REQUIRE_CUDA "cuda>=12.1 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526"
+ENV NV_CUDA_CUDART_VERSION 12.1.105-1
+
+COPY cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
+
+RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
+    echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
+
+ENV CUDA_VERSION 12.1.1
+
+# For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
+RUN yum upgrade -y && yum install -y \
+    cuda-cudart-12-1-${NV_CUDA_CUDART_VERSION} \
+    cuda-compat-12-1 \
+    && yum clean all \
+    && rm -rf /var/cache/yum/*
+
+# nvidia-docker 1.0
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+COPY NGC-DL-CONTAINER-LICENSE /
+
+# nvidia-container-runtime
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+# Install CUDA runtime from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/runtime/Dockerfile
+ENV NV_CUDA_LIB_VERSION 12.1.1-1
+ENV NV_NVTX_VERSION 12.1.105-1
+ENV NV_LIBNPP_VERSION 12.1.0.40-1
+ENV NV_LIBNPP_PACKAGE libnpp-12-1-${NV_LIBNPP_VERSION}
+ENV NV_LIBCUBLAS_VERSION 12.1.3.1-1
+ENV NV_LIBNCCL_PACKAGE_NAME libnccl
+ENV NV_LIBNCCL_PACKAGE_VERSION 2.17.1-1
+ENV NV_LIBNCCL_VERSION 2.17.1
+ENV NCCL_VERSION 2.17.1
+ENV NV_LIBNCCL_PACKAGE ${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda12.1
+
+RUN yum install -y \
+    cuda-libraries-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-nvtx-12-1-${NV_NVTX_VERSION} \
+    ${NV_LIBNPP_PACKAGE} \
+    libcublas-12-1-${NV_LIBCUBLAS_VERSION} \
+    ${NV_LIBNCCL_PACKAGE} \
+    && yum clean all \
+    && rm -rf /var/cache/yum/*
+
+# Set this flag so that libraries can find the location of CUDA
+ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
+
+# Install CUDA devel from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/devel/Dockerfile
+ENV NV_CUDA_LIB_VERSION 12.1.1-1
+ENV NV_NVPROF_VERSION 12.1.105-1
+ENV NV_NVPROF_DEV_PACKAGE cuda-nvprof-12-1-${NV_NVPROF_VERSION}
+ENV NV_CUDA_CUDART_DEV_VERSION 12.1.105-1
+ENV NV_NVML_DEV_VERSION 12.1.105-1
+ENV NV_LIBCUBLAS_DEV_VERSION 12.1.3.1-1
+ENV NV_LIBNPP_DEV_VERSION 12.1.0.40-1
+ENV NV_LIBNPP_DEV_PACKAGE libnpp-devel-12-1-${NV_LIBNPP_DEV_VERSION}
+ENV NV_LIBNCCL_DEV_PACKAGE_NAME libnccl-devel
+ENV NV_LIBNCCL_DEV_PACKAGE_VERSION 2.17.1-1
+ENV NCCL_VERSION 2.17.1
+ENV NV_LIBNCCL_DEV_PACKAGE ${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.1
+ENV NV_CUDA_NSIGHT_COMPUTE_VERSION 12.1.1-1
+ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE cuda-nsight-compute-12-1-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
+
+RUN yum install -y \
+    make \
+    findutils \
+    cuda-command-line-tools-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-libraries-devel-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-minimal-build-12-1-${NV_CUDA_LIB_VERSION} \
+    cuda-cudart-devel-12-1-${NV_CUDA_CUDART_DEV_VERSION} \
+    ${NV_NVPROF_DEV_PACKAGE} \
+    cuda-nvml-devel-12-1-${NV_NVML_DEV_VERSION} \
+    libcublas-devel-12-1-${NV_LIBCUBLAS_DEV_VERSION} \
+    ${NV_LIBNPP_DEV_PACKAGE} \
+    ${NV_LIBNCCL_DEV_PACKAGE} \
+    ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
+    && yum clean all \
+    && rm -rf /var/cache/yum/*
+
+ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
+
+# Install CUDA devel cudnn8 from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/devel/cudnn8/Dockerfile
+ENV NV_CUDNN_VERSION 8.9.0.131-1
+ENV NV_CUDNN_PACKAGE libcudnn8-${NV_CUDNN_VERSION}.cuda12.1
+ENV NV_CUDNN_PACKAGE_DEV libcudnn8-devel-${NV_CUDNN_VERSION}.cuda12.1
+
+LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
+
+RUN yum install -y \
+    ${NV_CUDNN_PACKAGE} \
+    ${NV_CUDNN_PACKAGE_DEV} \
+    && yum clean all \
+    && rm -rf /var/cache/yum/*
+
+# Install Ray
+RUN python3 -m pip install --no-cache-dir -U pip \
+    'ray[all]==2.23.0'
+
+# Restore user workspace
+USER 1001
+WORKDIR /opt/app-root/src

--- a/images/runtime/ray/Dockerfile
+++ b/images/runtime/ray/Dockerfile
@@ -120,6 +120,7 @@ RUN yum install -y \
 
 # Install Ray
 RUN python3 -m pip install --no-cache-dir -U pip \
+    'numpy<2.0.0' \
     'ray[all]==2.23.0'
 
 # Restore user workspace

--- a/images/runtime/ray/Dockerfile
+++ b/images/runtime/ray/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.access.redhat.com/ubi9/python-311:latest
+FROM registry.access.redhat.com/ubi9/python-39:latest
 
-LABEL name="ray-ubi9-py311-cu121" \
-      summary="CUDA 12.1 Python 3.11 image based on UBI9 for Ray" \
-      description="CUDA 12.1 Python 3.11 image based on UBI9 for Ray" \
-      io.k8s.display-name="CUDA 12.1 Python 3.11 base image for Ray" \
-      io.k8s.description="CUDA 12.1 Python 3.11 image based on UBI9 for Ray" \
+LABEL name="ray-ubi9-py39-cu121" \
+      summary="CUDA 12.1 Python 3.9 image based on UBI9 for Ray" \
+      description="CUDA 12.1 Python 3.9 image based on UBI9 for Ray" \
+      io.k8s.display-name="CUDA 12.1 Python 3.9 base image for Ray" \
+      io.k8s.description="CUDA 12.1 Python 3.9 image based on UBI9 for Ray" \
       authoritative-source-url="https://github.com/opendatahub-io/distributed-workloads"
 
 # Install CUDA base from:

--- a/images/runtime/ray/NGC-DL-CONTAINER-LICENSE
+++ b/images/runtime/ray/NGC-DL-CONTAINER-LICENSE
@@ -1,0 +1,285 @@
+NVIDIA DEEP LEARNING CONTAINER LICENSE
+
+This license is a legal agreement between you and NVIDIA Corporation ("NVIDIA")
+and governs the use of the NVIDIA container and all its contents (“CONTAINER”).
+
+This license can be accepted only by an adult of legal age of majority in the
+country in which the CONTAINER is used. If you are under the legal age of
+majority, you must ask your parent or legal guardian to consent to this license.
+If you are entering this license on behalf of a company or other legal entity,
+you represent that you have legal authority and “you” will mean the entity you
+represent.
+
+By using the CONTAINER, you affirm that you have reached the legal age of
+majority, you accept the terms of this license, and you take legal and financial
+responsibility for the actions of your permitted users.
+
+You agree to use the CONTAINER only for purposes that are permitted by (a) this
+license, and (b) any applicable law, regulation or generally accepted practices
+or guidelines in the relevant jurisdictions.
+
+1. LICENSE. Subject to the terms of this license, NVIDIA hereby grants you a
+non-exclusive, non-transferable license, without the right to sublicense (except
+as expressly provided in this license) to:
+
+a. Install and use copies of the CONTAINER, and modify and create derivative
+works of samples or example source code delivered in the CONTAINER (if
+applicable), to develop and test services and applications,
+
+b. Deploy the CONTAINER on infrastructure you own or lease to offer a service to
+third parties, without distributing the CONTAINER or exposing the NVIDIA APIs in
+the CONTAINER directly to such service users, and
+
+c. Develop and extend the CONTAINER to create a Compatible (as defined below)
+derived CONTAINER that includes the entire CONTAINER plus other software with
+primary functionality, to develop and compile applications, and distribute such
+derived CONTAINER to run applications, subject to the distribution requirements
+indicated in this license. As used in this section, “Compatible” means that
+extensions to the CONTAINER must not adversely affect the functionality of the
+other components in the CONTAINER.
+
+2. DISTRIBUTION REQUIREMENTS. For purposes of this Section 2, the term
+“distribution” also means the deployment of CONTAINERS in a service or an
+application for third parties to access over the internet. These are the
+distribution requirements for you to exercise the grants above:
+
+a. A service or an application must have material additional functionality,
+beyond the included portions of the CONTAINER.
+
+b. The following notice shall be included in modifications and derivative works
+of source code distributed: “This software contains source code provided by
+NVIDIA Corporation.”
+
+c. You agree to distribute the CONTAINER subject to the terms at least as
+protective as the terms of this license, including (without limitation) terms
+relating to the license grant, license restrictions and protection of NVIDIA’s
+intellectual property rights. Additionally, you agree that you will protect the
+privacy, security and legal rights of your application users.
+
+d. You agree to notify NVIDIA in writing of any known or suspected distribution
+or use of the CONTAINER not in compliance with the requirements of this license,
+and to enforce the terms of your agreements with respect to the distributed
+CONTAINER.
+
+3. AUTHORIZED USERS. You may allow employees and contractors of your entity or
+of your subsidiary(ies) to access and use the CONTAINER from your secure network
+to perform work on your behalf. If you are an academic institution you may allow
+users enrolled or employed by the academic institution to access and use the
+CONTAINER from your secure network. You are responsible for the compliance with
+the terms of this license by your authorized users.
+
+4. LIMITATIONS. Your license to use the CONTAINER is restricted as follows:
+
+a. The CONTAINER may run on any computing system with or without NVIDIA GPUs,
+except for the NVIDIA proprietary software (such as CUDA and TensorRT software)
+in the CONTAINER which is licensed only to run on systems with NVIDIA GPUs. The
+NVIDIA proprietary software in the CONTAINER may be present on systems without
+NVIDIA GPUs, as long as it is not running on such systems. For components
+governed by open source software licenses, see the information in the
+“Components Under Other Licenses” section below.
+
+b. You may not reverse engineer, decompile or disassemble, or remove copyright
+or other proprietary notices from any portion of the CONTAINER or copies of the
+CONTAINER.
+
+c. Except as expressly provided in this license, you may not copy, sell, rent,
+sublicense, transfer, distribute, modify, or create derivative works of any
+portion of the CONTAINER. For clarity, you may not distribute or sublicense the
+CONTAINER as a stand-alone product.
+
+d. Unless you have an agreement with NVIDIA for this purpose, you may not
+indicate that a service or an application created with the CONTAINER is
+sponsored or endorsed by NVIDIA.
+
+e. You may not bypass, disable, or circumvent any technical limitation,
+encryption, security, digital rights management or authentication mechanism in
+the CONTAINER.
+
+f. You may not replace any NVIDIA software components in the CONTAINER that are
+governed by this license with other software that implements NVIDIA APIs.
+
+g. You may not use the CONTAINER in any manner that would cause it to become
+subject to an open source software license. As examples, licenses that require
+as a condition of use, modification, and/or distribution that the CONTAINER be:
+(i) disclosed or distributed in source code form; (ii) licensed for the purpose
+of making derivative works; or (iii) redistributable at no charge.
+
+h. You acknowledge that the CONTAINER as delivered is not tested or certified by
+NVIDIA for use in connection with the design, construction, maintenance, and/or
+operation of any system where the use or failure of such system could result in
+a situation that threatens the safety of human life or results in catastrophic
+damages (each, a “Critical Application”). Examples of Critical Applications
+include use in avionics, navigation, autonomous vehicle applications, ai
+solutions for automotive products, military, medical, life support or other life
+critical applications. NVIDIA shall not be liable to you or any third party, in
+whole or in part, for any claims or damages arising from such uses. You are
+solely responsible for ensuring that any product or service developed with the
+CONTAINER as a whole includes sufficient features to comply with all applicable
+legal and regulatory standards and requirements.
+
+i. You agree to defend, indemnify and hold harmless NVIDIA and its affiliates,
+and their respective employees, contractors, agents, officers and directors,
+from and against any and all claims, damages, obligations, losses, liabilities,
+costs or debt, fines, restitutions and expenses (including but not limited to
+attorney’s fees and costs incident to establishing the right of indemnification)
+arising out of or related to products or services that use the CONTAINER in or
+for Critical Applications, and for use of the CONTAINER outside of the scope of
+this license or not in compliance with its terms.
+
+j. You may not reverse engineer, decompile or disassemble any portion of the
+output generated using the NVIDIA proprietary software (such as CUDA and
+TensorRT software) in the CONTAINER for the purpose of translating such output
+artifacts to target a non-NVIDIA platform.
+
+5. UPDATES. NVIDIA may, at its option, make available patches, workarounds or
+other updates to this CONTAINER. Unless the updates are provided with their
+separate governing terms, they are deemed part of the CONTAINER licensed to you
+as provided in this license. You agree that the form and content of the
+CONTAINER that NVIDIA provides may change without prior notice to you. While
+NVIDIA generally maintains compatibility between versions, NVIDIA may in some
+cases make changes that introduce incompatibilities in future versions of the
+CONTAINER.
+
+6. PRE-RELEASE VERSIONS. CONTAINER versions identified as alpha, beta, preview,
+early access or otherwise as pre-release may not be fully functional, may
+contain errors or design flaws, and may have reduced or different security,
+privacy, availability, and reliability standards relative to commercial versions
+of NVIDIA software and materials. You may use a pre- release CONTAINER version
+at your own risk, understanding that these versions are not intended for use in
+production or business-critical systems. NVIDIA may choose not to make available
+a commercial version of any pre-release CONTAINER. NVIDIA may also choose to
+abandon development and terminate the availability of a pre-release CONTAINER at
+any time without liability.
+
+7. COMPONENTS UNDER OTHER LICENSES. The CONTAINER may include NVIDIA or
+third-party components with separate legal notices or terms as may be described
+in proprietary notices accompanying the CONTAINER. If and to the extent there is
+a conflict between the terms in this license and the license terms associated
+with the component, the license terms associated with the components control
+only to the extent necessary to resolve the conflict. For example, some Triton
+components (such as the Triton Inference Server) are governed by open source
+software licenses.
+
+You acknowledge and agree that it is your sole responsibility to obtain any
+additional third-party licenses required to make, have made, use, have used,
+sell, import, and offer for sale your products or services that include or
+incorporate any third- party software and content relating to audio and/or video
+encoders and decoders from, including but not limited to, Microsoft, Thomson,
+Fraunhofer IIS, Sisvel S.p.A., MPEG-LA, and Coding Technologies. NVIDIA does not
+grant to you under this license any necessary patent or other rights with
+respect to any audio and/or video encoders and decoders. Subject to the other
+terms of this license, you may use the CONTAINER to develop and test
+applications released under Open Source Initiative (OSI) approved open source
+software licenses.
+
+8. OWNERSHIP.
+
+8.1 NVIDIA reserves all rights, title and interest in and to the CONTAINER not
+expressly granted to you under this license. NVIDIA and its suppliers hold all
+rights, title and interest in and to the CONTAINER, including their respective
+intellectual property rights. The CONTAINER is copyrighted and protected by the
+laws of the United States and other countries, and international treaty
+provisions.
+
+8.2 Subject to the rights of NVIDIA and its suppliers in the CONTAINER, you hold
+all rights, title and interest in and to your services, applications and your
+derivative works of the sample source code delivered in the CONTAINER including
+their respective intellectual property rights.
+
+9. FEEDBACK. You may, but are not obligated to, provide to NVIDIA suggestions,
+fixes, modifications, feature requests or other feedback regarding the CONTAINER
+(“Feedback”). Feedback, even if designated as confidential by you, shall not
+create any confidentiality obligation for NVIDIA. NVIDIA and its designees have
+a perpetual, non-exclusive, worldwide, irrevocable license to use, reproduce,
+publicly display, modify, create derivative works of, license, sublicense, and
+otherwise distribute and exploit Feedback as NVIDIA sees fit without payment and
+without obligation or restriction of any kind on account of intellectual
+property rights or otherwise.
+
+10. NO WARRANTIES. THE CONTAINER IS PROVIDED AS-IS. TO THE MAXIMUM EXTENT
+PERMITTED BY APPLICABLE LAW NVIDIA AND ITS AFFILIATES EXPRESSLY DISCLAIM ALL
+WARRANTIES OF ANY KIND OR NATURE, WHETHER EXPRESS, IMPLIED OR STATUTORY,
+INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT,
+OR FITNESS FOR A PARTICULAR PURPOSE. NVIDIA DOES NOT WARRANT THAT THE CONTAINER
+WILL MEET YOUR REQUIREMENTS OR THAT THE OPERATION THEREOF WILL BE UNINTERRUPTED
+OR ERROR-FREE, OR THAT ALL ERRORS WILL BE CORRECTED.
+
+11. LIMITATIONS OF LIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW
+NVIDIA AND ITS AFFILIATES SHALL NOT BE LIABLE FOR ANY SPECIAL, INCIDENTAL,
+PUNITIVE OR CONSEQUENTIAL DAMAGES, OR FOR ANY LOST PROFITS, PROJECT DELAYS, LOSS
+OF USE, LOSS OF DATA OR LOSS OF GOODWILL, OR THE COSTS OF PROCURING SUBSTITUTE
+PRODUCTS, ARISING OUT OF OR IN CONNECTION WITH THIS LICENSE OR THE USE OR
+PERFORMANCE OF THE CONTAINER, WHETHER SUCH LIABILITY ARISES FROM ANY CLAIM BASED
+UPON BREACH OF CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING NEGLIGENCE),
+PRODUCT LIABILITY OR ANY OTHER CAUSE OF ACTION OR THEORY OF LIABILITY, EVEN IF
+NVIDIA HAS PREVIOUSLY BEEN ADVISED OF, OR COULD REASONABLY HAVE FORESEEN, THE
+POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL NVIDIA’S AND ITS AFFILIATES TOTAL
+CUMULATIVE LIABILITY UNDER OR ARISING OUT OF THIS LICENSE EXCEED US$10.00. THE
+NATURE OF THE LIABILITY OR THE NUMBER OF CLAIMS OR SUITS SHALL NOT ENLARGE OR
+EXTEND THIS LIMIT.
+
+12. TERMINATION. Your rights under this license will terminate automatically
+without notice from NVIDIA if you fail to comply with any term and condition of
+this license or if you commence or participate in any legal proceeding against
+NVIDIA with respect to the CONTAINER. NVIDIA may terminate this license with
+advance written notice to you, if NVIDIA decides to no longer provide the
+CONTAINER in a country or, in NVIDIA’s sole discretion, the continued use of it
+is no longer commercially viable. Upon any termination of this license, you
+agree to promptly discontinue use of the CONTAINER and destroy all copies in
+your possession or control. Your prior distributions in accordance with this
+license are not affected by the termination of this license. All provisions of
+this license will survive termination, except for the license granted to you.
+
+13. APPLICABLE LAW. This license will be governed in all respects by the laws of
+the United States and of the State of Delaware, without regard to the conflicts
+of laws principles. The United Nations Convention on Contracts for the
+International Sale of Goods is specifically disclaimed. You agree to all terms
+of this license in the English language. The state or federal courts residing in
+Santa Clara County, California shall have exclusive jurisdiction over any
+dispute or claim arising out of this license. Notwithstanding this, you agree
+that NVIDIA shall still be allowed to apply for injunctive remedies or urgent
+legal relief in any jurisdiction.
+
+14. NO ASSIGNMENT. This license and your rights and obligations thereunder may
+not be assigned by you by any means or operation of law without NVIDIA’s
+permission. Any attempted assignment not approved by NVIDIA in writing shall be
+void and of no effect. NVIDIA may assign, delegate or transfer this license and
+its rights and obligations, and if to a non-affiliate you will be notified.
+
+15. EXPORT. The CONTAINER is subject to United States export laws and
+regulations. You agree to comply with all applicable U.S. and international
+export laws, including the Export Administration Regulations (EAR) administered
+by the U.S. Department of Commerce and economic sanctions administered by the
+U.S. Department of Treasury’s Office of Foreign Assets Control (OFAC). These
+laws include restrictions on destinations, end-users and end-use. By accepting
+this license, you confirm that you are not currently residing in a country or
+region currently embargoed by the U.S. and that you are not otherwise prohibited
+from receiving the CONTAINER.
+
+16. GOVERNMENT USE. The CONTAINER is, and shall be treated as being, “Commercial
+Items” as that term is defined at 48 CFR § 2.101, consisting of “commercial
+computer software” and “commercial computer software documentation”,
+respectively, as such terms are used in, respectively, 48 CFR § 12.212 and 48
+CFR §§ 227.7202 & 252.227-7014(a)(1). Use, duplication or disclosure by the U.S.
+Government or a U.S. Government subcontractor is subject to the restrictions in
+this license pursuant to 48 CFR § 12.212 or 48 CFR § 227.7202. In no event shall
+the US Government user acquire rights in the CONTAINER beyond those specified in
+48 C.F.R. 52.227-19(b)(1)-(2).
+
+17. NOTICES. Please direct your legal notices or other correspondence to NVIDIA
+Corporation, 2788 San Tomas Expressway, Santa Clara, California 95051, United
+States of America, Attention: Legal Department. 18. ENTIRE AGREEMENT. This
+license is the final, complete and exclusive agreement between the parties
+relating to the subject matter of this license and supersedes all prior or
+contemporaneous understandings and agreements relating to this subject matter,
+whether oral or written. If any court of competent jurisdiction determines that
+any provision of this license is illegal, invalid or unenforceable, the
+remaining provisions will remain in full force and effect. Any amendment or
+waiver under this license shall be in writing and signed by representatives of
+both parties.
+
+19. LICENSING. If the distribution terms in this license are not suitable for
+your organization, or for any questions regarding this license, please contact
+NVIDIA at nvidia-compute-license-questions@nvidia.com.
+
+(v. September 14, 2021)

--- a/images/runtime/ray/README.md
+++ b/images/runtime/ray/README.md
@@ -3,7 +3,7 @@
 Default base container image for Ray in OpenShift AI.
 
 It includes the following layers:
-* UBI9
-* Python 3.11
+* UBI 9
+* Python 3.9
 * CUDA 12.1
 * Ray 2.23.0

--- a/images/runtime/ray/README.md
+++ b/images/runtime/ray/README.md
@@ -1,0 +1,9 @@
+# Ray Runtime Container Image
+
+Default base container image for Ray in OpenShift AI.
+
+It includes the following layers:
+* UBI9
+* Python 3.11
+* CUDA 12.1
+* Ray 2.23.0

--- a/images/runtime/ray/cuda.repo-arm64
+++ b/images/runtime/ray/cuda.repo-arm64
@@ -1,0 +1,6 @@
+[cuda]
+name=cuda
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA

--- a/images/runtime/ray/cuda.repo-x86_64
+++ b/images/runtime/ray/cuda.repo-x86_64
@@ -1,0 +1,6 @@
+[cuda]
+name=cuda
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA


### PR DESCRIPTION
## Description

Provide a base Ray container image for Distributed Workloads, that includes the following layers / components:
* UBI 9
* Python 3.9
* CUDA 12.1
* Ray 2.23.0

Document how to build a custom container image on top of that base Ray container image. 

See https://issues.redhat.com/browse/RHOAIENG-7846 and https://issues.redhat.com/browse/RHOAIENG-7875.

## How Has This Been Tested?

This image has been successfully tested with the [ray-finetune-llm-deepspeed](https://github.com/opendatahub-io/distributed-workloads/tree/main/examples/ray-finetune-llm-deepspeed) example, by building a custom image on top of it, containing PyTorch 2.3.1, and fine-tuning Llama 7B model over several epochs (~10h run):

![image](https://github.com/opendatahub-io/distributed-workloads/assets/366207/ca08d150-c0b5-4b2e-85d9-c2c1a07e433a)

The Ray dashboard is working as expected, and GPU utilisation nominal:

![image](https://github.com/opendatahub-io/distributed-workloads/assets/366207/4b75a147-3616-4414-948c-d8a19e06ac6f)


