### PR TITLE
Fix Pytorch lightning version

### DIFF
--- a/tests/odh/resources/requirements.txt
+++ b/tests/odh/resources/requirements.txt
@@ -1,6 +1,6 @@
 {{.PipIndexUrl}}
 {{.PipTrustedHost}}
-pytorch_lightning==1.5.10
+pytorch_lightning==1.9.5
 ray_lightning
 torchmetrics==0.9.1
 torchvision==0.12.0


### PR DESCRIPTION
Latest pip is not able to install previous version.