### PR TITLE
Use Ray base container image in fine-tuning example

### DIFF
--- a/examples/ray-finetune-llm-deepspeed/ray_finetune_llm_deepspeed.ipynb
+++ b/examples/ray-finetune-llm-deepspeed/ray_finetune_llm_deepspeed.ipynb
@@ -69,7 +69,7 @@
     "    head_memory=128,\n",
     "    head_gpus=1,\n",
     "    num_gpus=1,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121-torch\",\n",
+    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
     "))"
    ]
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR updates the `ray-finetune-llm-deepspeed` to use the Ray base container image directly, instead of the custom PyTorch one.

This is possible since Flash Attention 2 is installed from wheel file directly, which does not require PyTorch to be pre-installed. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran the `ray-finetune-llm-deepspeed` example.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
