### PR TITLE
Update tests to use default local queue created in given namespace

### DIFF
--- a/tests/kfto/core/kfto_kueue_sft_test.go
+++ b/tests/kfto/core/kfto_kueue_sft_test.go
@@ -79,7 +79,10 @@ func runPytorchjobWithSFTtrainer(t *testing.T, modelConfigFile string) {
 	}
 	clusterQueue := CreateKueueClusterQueue(test, cqSpec)
 	defer test.Client().Kueue().KueueV1beta1().ClusterQueues().Delete(test.Ctx(), clusterQueue.Name, metav1.DeleteOptions{})
-	localQueue := CreateKueueLocalQueue(test, namespace.Name, clusterQueue.Name)
+	annotations := map[string]string{
+		"kueue.x-k8s.io/default-queue": "true",
+	}
+	localQueue := CreateKueueLocalQueue(test, namespace.Name, clusterQueue.Name, annotations)
 
 	// Create training PyTorch job
 	tuningJob := createPyTorchJob(test, namespace.Name, localQueue.Name, *config)
@@ -143,7 +146,10 @@ func TestPytorchjobUsingKueueQuota(t *testing.T) {
 	}
 	clusterQueue := CreateKueueClusterQueue(test, cqSpec)
 	defer test.Client().Kueue().KueueV1beta1().ClusterQueues().Delete(test.Ctx(), clusterQueue.Name, metav1.DeleteOptions{})
-	localQueue := CreateKueueLocalQueue(test, namespace.Name, clusterQueue.Name)
+	annotations := map[string]string{
+		"kueue.x-k8s.io/default-queue": "true",
+	}
+	localQueue := CreateKueueLocalQueue(test, namespace.Name, clusterQueue.Name, annotations)
 
 	// Create first training PyTorch job
 	tuningJob := createPyTorchJob(test, namespace.Name, localQueue.Name, *config)

--- a/tests/kfto/upgrade/kfto_kueue_sft_upgrade_training_test.go
+++ b/tests/kfto/upgrade/kfto_kueue_sft_upgrade_training_test.go
@@ -99,7 +99,10 @@ func TestSetupPytorchjob(t *testing.T) {
 	clusterQueue, err = test.Client().Kueue().KueueV1beta1().ClusterQueues().Create(test.Ctx(), clusterQueue, metav1.CreateOptions{})
 	test.Expect(err).NotTo(HaveOccurred())
 
-	localQueue := CreateKueueLocalQueue(test, namespaceName, clusterQueue.Name)
+	annotations := map[string]string{
+		"kueue.x-k8s.io/default-queue": "true",
+	}
+	localQueue := CreateKueueLocalQueue(test, namespaceName, clusterQueue.Name, annotations)
 
 	// Create training PyTorch job
 	tuningJob := createPyTorchJob(test, namespaceName, localQueue.Name, *config)

--- a/tests/odh/mnist_raytune_hpo_test.go
+++ b/tests/odh/mnist_raytune_hpo_test.go
@@ -76,7 +76,10 @@ func mnistRayTuneHpo(t *testing.T, numGpus int) {
 	}
 	clusterQueue := CreateKueueClusterQueue(test, cqSpec)
 	defer test.Client().Kueue().KueueV1beta1().ClusterQueues().Delete(test.Ctx(), clusterQueue.Name, metav1.DeleteOptions{})
-	localQueue := CreateKueueLocalQueue(test, namespace.Name, clusterQueue.Name)
+	annotations := map[string]string{
+		"kueue.x-k8s.io/default-queue": "true",
+	}
+	CreateKueueLocalQueue(test, namespace.Name, clusterQueue.Name, annotations)
 
 	// Test configuration
 	jupyterNotebookConfigMapFileName := "mnist_hpo_raytune.ipynb"
@@ -103,7 +106,7 @@ func mnistRayTuneHpo(t *testing.T, numGpus int) {
 	CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
 
 	// Create Notebook CR
-	createNotebook(test, namespace, userToken, localQueue.Name, config.Name, jupyterNotebookConfigMapFileName, numGpus)
+	createNotebook(test, namespace, userToken, config.Name, jupyterNotebookConfigMapFileName, numGpus)
 
 	// Gracefully cleanup Notebook
 	defer func() {

--- a/tests/odh/notebook.go
+++ b/tests/odh/notebook.go
@@ -41,14 +41,13 @@ type NotebookProps struct {
 	OpenDataHubNamespace      string
 	RayImage                  string
 	NotebookImage             string
-	LocalQueue                string
 	NotebookConfigMapName     string
 	NotebookConfigMapFileName string
 	NotebookPVC               string
 	NumGpus                   int
 }
 
-func createNotebook(test Test, namespace *corev1.Namespace, notebookUserToken, localQueue, jupyterNotebookConfigMapName, jupyterNotebookConfigMapFileName string, numGpus int) {
+func createNotebook(test Test, namespace *corev1.Namespace, notebookUserToken, jupyterNotebookConfigMapName, jupyterNotebookConfigMapFileName string, numGpus int) {
 	// Create PVC for Notebook
 	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", corev1.ReadWriteOnce)
 
@@ -61,7 +60,6 @@ func createNotebook(test Test, namespace *corev1.Namespace, notebookUserToken, l
 		OpenDataHubNamespace:      GetOpenDataHubNamespace(test),
 		RayImage:                  GetRayImage(),
 		NotebookImage:             GetNotebookImage(test),
-		LocalQueue:                localQueue,
 		NotebookConfigMapName:     jupyterNotebookConfigMapName,
 		NotebookConfigMapFileName: jupyterNotebookConfigMapFileName,
 		NotebookPVC:               notebookPVC.Name,

--- a/tests/odh/resources/custom-nb-small.yaml
+++ b/tests/odh/resources/custom-nb-small.yaml
@@ -51,7 +51,7 @@ spec:
         - name: JUPYTER_NOTEBOOK_PORT
           value: "8888"
         image: {{.NotebookImage}}
-        command: ["/bin/sh", "-c", "pip install papermill && papermill /opt/app-root/notebooks/{{.NotebookConfigMapFileName}} /opt/app-root/src/mcad-out.ipynb -p namespace {{.Namespace}} -p ray_image {{.RayImage}} -p local_queue {{.LocalQueue}} -p openshift_api_url {{.OpenShiftApiUrl}} -p kubernetes_user_bearer_token {{.KubernetesUserBearerToken}} -p num_gpus {{ .NumGpus }} --log-output && sleep infinity"]
+        command: ["/bin/sh", "-c", "pip install papermill && papermill /opt/app-root/notebooks/{{.NotebookConfigMapFileName}} /opt/app-root/src/mcad-out.ipynb -p namespace {{.Namespace}} -p ray_image {{.RayImage}} -p openshift_api_url {{.OpenShiftApiUrl}} -p kubernetes_user_bearer_token {{.KubernetesUserBearerToken}} -p num_gpus {{ .NumGpus }} --log-output && sleep infinity"]
         # args: ["pip install papermill && oc login --token=${OCP_TOKEN} --server=${OCP_SERVER} --insecure-skip-tls-verify=true && papermill /opt/app-root/notebooks/mcad.ipynb /opt/app-root/src/mcad-out.ipynb" ]
         imagePullPolicy: Always
         # livenessProbe:

--- a/tests/odh/resources/mnist_hpo_raytune.ipynb
+++ b/tests/odh/resources/mnist_hpo_raytune.ipynb
@@ -42,7 +42,6 @@
     "#parameters\n",
     "namespace = \"default\"\n",
     "ray_image = \"has to be specified\"\n",
-    "local_queue = \"has to be specified\"\n",
     "openshift_api_url = \"has to be specified\"\n",
     "kubernetes_user_bearer_token = \"has to be specified\"\n",
     "num_gpus = \"has to be specified\""
@@ -87,7 +86,6 @@
     "        max_memory=4,\n",
     "        num_gpus=int(num_gpus),\n",
     "        image=ray_image,\n",
-    "        local_queue=local_queue,\n",
     "        write_to_file=True,\n",
     "        verify_tls=False\n",
     "    )\n",

--- a/tests/odh/resources/mnist_ray_mini.ipynb
+++ b/tests/odh/resources/mnist_ray_mini.ipynb
@@ -42,7 +42,6 @@
     "#parameters\n",
     "namespace = \"default\"\n",
     "ray_image = \"has to be specified\"\n",
-    "local_queue = \"has to be specified\"\n",
     "openshift_api_url = \"has to be specified\"\n",
     "kubernetes_user_bearer_token = \"has to be specified\"\n",
     "num_gpus = \"has to be specified\""
@@ -87,7 +86,6 @@
     "        max_memory=4,\n",
     "        num_gpus=int(num_gpus),\n",
     "        image=ray_image,\n",
-    "        local_queue=local_queue,\n",
     "        write_to_file=True,\n",
     "        verify_tls=False\n",
     "    )\n",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update tests to use default local queue created in given namespace to skip local-queue usage in raycluster configuration function.
Depends on : https://github.com/project-codeflare/codeflare-common/pull/59

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Skipped providing local-queue parameter in raycluster configuration function to create a raycluster with default kueue label

![image (116)](https://github.com/user-attachments/assets/7b821422-39ed-4a83-b924-04ed9b902a6c)
![image (114)](https://github.com/user-attachments/assets/1e9e88c1-d4c7-48f9-85bd-3ba16bb28d85)
![image (115)](https://github.com/user-attachments/assets/e9037678-7e7b-4654-be93-719d4611ce1b)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
