### PR TITLE
Update HPO Ray Tune GPU test

### DIFF
--- a/tests/odh/resources/mnist_hpo_raytune.ipynb
+++ b/tests/odh/resources/mnist_hpo_raytune.ipynb
@@ -170,7 +170,7 @@
     "        \"working_dir\": \"/opt/app-root/notebooks/..data\",\n",
     "        \"pip\": \"/opt/app-root/notebooks/hpo_raytune_requirements.txt\",\n",
     "    },\n",
-    "    entrypoint_num_gpus=num_gpus\n",
+    "    # entrypoint_num_gpus is not required here as the mnist_hpo script executes in parallel and requires more GPUs for each iteration\n",
     ")"
    ]
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Test `TestMnistRayTuneHpoGpu` failing due to improper gpu configuration.
Removing Parameter`entrypoint_num_gpus`as mnist_hpo script executes in parallel and requires more GPUs for each iteration
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Installed latest RHOAI version on cluster with GPU enabled
- Run the test `go test -v ./tests/odh -run  TestMnistRayTuneHpoGpu`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
