### PR TITLE
Increase memory requirements for KFTO tests

### DIFF
--- a/tests/kfto/core/kfto_kueue_sft_test.go
+++ b/tests/kfto/core/kfto_kueue_sft_test.go
@@ -133,7 +133,7 @@ func TestPytorchjobUsingKueueQuota(t *testing.T) {
 							},
 							{
 								Name:         corev1.ResourceMemory,
-								NominalQuota: resource.MustParse("6Gi"),
+								NominalQuota: resource.MustParse("8Gi"),
 							},
 						},
 					},
@@ -234,7 +234,11 @@ func createPyTorchJob(test Test, namespace, localQueueName string, config corev1
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("2"),
-											corev1.ResourceMemory: resource.MustParse("5Gi"),
+											corev1.ResourceMemory: resource.MustParse("7Gi"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("2"),
+											corev1.ResourceMemory: resource.MustParse("7Gi"),
 										},
 									},
 									SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Current memory requirements for KFTO integration tests weren't sufficient enough. 
The memory issue was hidden by a fact that resource limits weren't set, so PyTorchJob pod took more memory if cluster has more memory to share. The memory issue happened just on clusters which had limited resources.

By setting resource limits I make sure that the test results are reproducible on any environment, regardless of free resources.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on OCP cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
