### PR TITLE
KFTO: Remove tokenizer_name_or_path parameters in tests

### DIFF
--- a/tests/kfto/core/config.json
+++ b/tests/kfto/core/config.json
@@ -13,6 +13,5 @@
     "include_tokens_per_second": true,
     "response_template": "\n### Label:",
     "dataset_text_field": "output",
-    "use_flash_attn": false,
-    "tokenizer_name_or_path": "/tmp/model/bloom-560m"
+    "use_flash_attn": false
 }

--- a/tests/kfto/core/config_granite_20b_code_instruct.json
+++ b/tests/kfto/core/config_granite_20b_code_instruct.json
@@ -13,6 +13,5 @@
     "include_tokens_per_second": true,
     "response_template": "\n### Response:",
     "dataset_text_field": "output",
-    "use_flash_attn": false,
-    "tokenizer_name_or_path": "ibm-granite/granite-20b-code-instruct"
+    "use_flash_attn": false
 }

--- a/tests/kfto/core/config_granite_34b_code_instruct_lora.json
+++ b/tests/kfto/core/config_granite_34b_code_instruct_lora.json
@@ -14,7 +14,6 @@
     "response_template": "\n### Response:",
     "dataset_text_field": "output",
     "use_flash_attn": false,
-    "tokenizer_name_or_path": "ibm-granite/granite-34b-code-instruct",
     "peft_method": "lora",
     "target_modules": ["all-linear"]
 }

--- a/tests/kfto/core/config_llama2_13b_chat_hf.json
+++ b/tests/kfto/core/config_llama2_13b_chat_hf.json
@@ -13,6 +13,5 @@
     "include_tokens_per_second": true,
     "response_template": "\n### Response:",
     "dataset_text_field": "output",
-    "use_flash_attn": false,
-    "tokenizer_name_or_path": "meta-llama/Llama-2-13b-chat-hf"
+    "use_flash_attn": false
 }

--- a/tests/kfto/core/config_llama2_13b_chat_hf_lora.json
+++ b/tests/kfto/core/config_llama2_13b_chat_hf_lora.json
@@ -14,6 +14,5 @@
     "response_template": "\n### Response:",
     "dataset_text_field": "output",
     "use_flash_attn": false,
-    "tokenizer_name_or_path": "meta-llama/Llama-2-13b-chat-hf",
     "peft_method": "lora"
 }

--- a/tests/kfto/core/config_lora.json
+++ b/tests/kfto/core/config_lora.json
@@ -14,7 +14,6 @@
     "response_template": "\n### Label:",
     "dataset_text_field": "output",
     "use_flash_attn": false,
-    "tokenizer_name_or_path": "/tmp/model/bloom-560m",
     "peft_method": "lora",
     "target_modules": ["all-linear"]
 }

--- a/tests/kfto/core/config_merlinite_7b.json
+++ b/tests/kfto/core/config_merlinite_7b.json
@@ -13,6 +13,5 @@
     "include_tokens_per_second": true,
     "response_template": "\n### Response:",
     "dataset_text_field": "output",
-    "use_flash_attn": false,
-    "tokenizer_name_or_path": "ibm/merlinite-7b"
+    "use_flash_attn": false
 }

--- a/tests/kfto/core/config_meta_llama3_1_70b_lora.json
+++ b/tests/kfto/core/config_meta_llama3_1_70b_lora.json
@@ -14,6 +14,5 @@
     "response_template": "\n### Response:",
     "dataset_text_field": "output",
     "use_flash_attn": false,
-    "tokenizer_name_or_path": "meta-llama/Meta-Llama-3.1-70B",
     "peft_method": "lora"
 }

--- a/tests/kfto/core/config_meta_llama3_1_8b.json
+++ b/tests/kfto/core/config_meta_llama3_1_8b.json
@@ -13,6 +13,5 @@
     "include_tokens_per_second": true,
     "response_template": "\n### Response:",
     "dataset_text_field": "output",
-    "use_flash_attn": false,
-    "tokenizer_name_or_path": "meta-llama/Meta-Llama-3.1-8B"
+    "use_flash_attn": false
 }

--- a/tests/kfto/core/config_meta_llama3_70b_instruct_lora.json
+++ b/tests/kfto/core/config_meta_llama3_70b_instruct_lora.json
@@ -14,6 +14,5 @@
     "response_template": "\n### Response:",
     "dataset_text_field": "output",
     "use_flash_attn": false,
-    "tokenizer_name_or_path": "meta-llama/Meta-Llama-3-70B-Instruct",
     "peft_method": "lora"
 }

--- a/tests/kfto/core/config_meta_llama3_8b_instruct.json
+++ b/tests/kfto/core/config_meta_llama3_8b_instruct.json
@@ -13,6 +13,5 @@
     "include_tokens_per_second": true,
     "response_template": "\n### Response:",
     "dataset_text_field": "output",
-    "use_flash_attn": false,
-    "tokenizer_name_or_path": "meta-llama/Meta-Llama-3-8B-Instruct"
+    "use_flash_attn": false
 }

--- a/tests/kfto/core/config_mixtral_8x7b_instruct_v01.json
+++ b/tests/kfto/core/config_mixtral_8x7b_instruct_v01.json
@@ -13,7 +13,6 @@
     "include_tokens_per_second": true,
     "response_template": "\n### Response:",
     "dataset_text_field": "output",
-    "use_flash_attn": false,
-    "tokenizer_name_or_path": "mistralai/Mixtral-8x7B-Instruct-v0.1"
+    "use_flash_attn": false
 }
 

--- a/tests/kfto/core/config_mixtral_8x7b_v01.json
+++ b/tests/kfto/core/config_mixtral_8x7b_v01.json
@@ -13,7 +13,6 @@
     "include_tokens_per_second": true,
     "response_template": "\n### Response:",
     "dataset_text_field": "output",
-    "use_flash_attn": false,
-    "tokenizer_name_or_path": "mistralai/Mixtral-8x7B-v0.1"
+    "use_flash_attn": false
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Parameter tokenizer_name_or_path should be used only in rare cases if user needs to provide custom tokenizer. By default the tokenizer is retrieved from the same path as model and all the needed tokens are provided.

Removing tokenizer_name_or_path parameter as it shouldn't be used unless there is some specific use case (no such use case in our tests for now).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by running integration tests against OCP.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
