### PR TITLE
Use stable channel for Nvidia GPU operator

### DIFF
--- a/examples/stable-diffusion-dreambooth/yaml/operators/nvidia.yaml
+++ b/examples/stable-diffusion-dreambooth/yaml/operators/nvidia.yaml
@@ -25,7 +25,7 @@ metadata:
   name: gpu-operator-certified
   namespace: nvidia-gpu-operator
 spec:
-  channel: v23.6
+  channel: stable
   installPlanApproval: Automatic
   name: gpu-operator-certified
   source: certified-operators


### PR DESCRIPTION
Use stable channel instead of hard coded version. The current version does not work with the latest OCP 4.16.10. The nvidia driver can not compile with this error

```
+ make -s -j SYSSRC=/lib/modules/5.14.0-427.33.1.el9_4.x86_64/build nv-linux.o nv-modeset-linux.o
ERROR: modpost: GPL-incompatible module nvidia.ko uses GPL-only symbol '__rcu_read_unlock'
ERROR: modpost: GPL-incompatible module nvidia.ko uses GPL-only symbol '__rcu_read_lock'
make[2]: *** [scripts/Makefile.modpost:134: /usr/src/nvidia-535.104.05/kernel/Module.symvers] Error 1
make[2]: *** Deleting file '/usr/src/nvidia-535.104.05/kernel/Module.symvers'
make[1]: *** [Makefile:1850: modules] Error 2
make: *** [Makefile:82: modules] Error 2
++ make -s -j SYSSRC=/lib/modules/5.14.0-427.33.1.el9_4.x86_64/build clean
```



## Description
Change the version to stable.

## How Has This Been Tested?
The channel version was changed to stable and noted the changes in the `subscription` instance.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
