### PR TITLE
E2E tests for kfto pytorch image

### DIFF
--- a/tests/kfto/core/environment.go
+++ b/tests/kfto/core/environment.go
@@ -42,12 +42,32 @@ const (
 	sleepImageEnvVar = "SLEEP_IMAGE"
 	// The environment variable specifying s3 bucket folder path used to store model
 	storageBucketModelPath = "AWS_STORAGE_BUCKET_MODEL_PATH"
+	// The environment variable for the CUDA training image
+	cudaTrainingImageEnvVar = "CUDA_TRAINING_IMAGE"
+	// The environment variable for the ROCm training image
+	rocmTrainingImageEnvVar = "ROCM_TRAINING_IMAGE"
 )
 
 func GetFmsHfTuningImage(t Test) string {
 	image, ok := os.LookupEnv(fmsHfTuningImageEnvVar)
 	if !ok {
 		t.T().Fatalf("Expected environment variable %s not found, please use this environment variable to specify fms-hf-tuning image to be tested.", fmsHfTuningImageEnvVar)
+	}
+	return image
+}
+
+func GetCudaTrainingImage(t Test) string {
+	image, ok := os.LookupEnv(cudaTrainingImageEnvVar)
+	if !ok {
+		t.T().Fatalf("Expected environment variable %s not found, please use this environment variable to specify the cuda training image to be tested.", cudaTrainingImageEnvVar)
+	}
+	return image
+}
+
+func GetROCmTrainingImage(t Test) string {
+	image, ok := os.LookupEnv(rocmTrainingImageEnvVar)
+	if !ok {
+		t.T().Fatalf("Expected environment variable %s not found, please use this environment variable to specify the cuda training image to be tested.", cudaTrainingImageEnvVar)
 	}
 	return image
 }

--- a/tests/kfto/core/hf_llm_training.py
+++ b/tests/kfto/core/hf_llm_training.py
@@ -1,0 +1,209 @@
+# Copyright 2023.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reference: https://github.com/kubeflow/training-operator/blob/master/sdk/python/kubeflow/trainer/hf_llm_training.py
+
+
+import argparse
+import logging
+from urllib.parse import urlparse
+import json
+import os
+
+from datasets import load_from_disk, Dataset
+from datasets.distributed import split_dataset_by_node
+from peft import LoraConfig, get_peft_model
+import transformers
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    AutoModelForImageClassification,
+    TrainingArguments,
+    DataCollatorForLanguageModeling,
+    Trainer,
+)
+
+
+# Configure logger.
+log_formatter = logging.Formatter(
+    "%(asctime)s %(levelname)-8s %(message)s", "%Y-%m-%dT%H:%M:%SZ"
+)
+logger = logging.getLogger(__file__)
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(log_formatter)
+logger.addHandler(console_handler)
+logger.setLevel(logging.INFO)
+
+
+def setup_model_and_tokenizer(model_uri, transformer_type, model_dir):
+    # Set up the model and tokenizer
+    parsed_uri = urlparse(model_uri)
+    model_name = parsed_uri.netloc + parsed_uri.path
+
+    model = transformer_type.from_pretrained(
+        pretrained_model_name_or_path=model_name,
+        cache_dir=model_dir,
+        local_files_only=True,
+        trust_remote_code=True,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        pretrained_model_name_or_path=model_name,
+        cache_dir=model_dir,
+        local_files_only=True,
+    )
+
+    # Freeze model parameters
+    for param in model.parameters():
+        param.requires_grad = False
+
+    return model, tokenizer
+
+# This function is a modified version of the original.
+def load_and_preprocess_data(dataset_dir, transformer_type, tokenizer):
+    # Load and preprocess the dataset
+    logger.info("Load and preprocess dataset")
+
+    file_path = os.path.realpath(dataset_dir)
+
+    if transformer_type != AutoModelForImageClassification:
+        dataset = load_from_disk(file_path)
+
+        logger.info(f"Dataset specification: {dataset}")
+        logger.info("-" * 40)
+
+        logger.info("Tokenize dataset")
+        # TODO (andreyvelich): Discuss how user should set the tokenizer function.
+        num_cores = os.cpu_count()
+        dataset = dataset.map(
+            lambda x: tokenizer(x["text"], padding=True, truncation=True, max_length=128),
+            batched=True,
+            num_proc=num_cores
+        )
+    else:
+        dataset = load_from_disk(file_path)
+
+    # Check if dataset contains `train` key. Otherwise, load full dataset to train_data.
+    if "train" in dataset:
+        train_data = dataset["train"]
+    else:
+        train_data = dataset
+
+    try:
+        eval_data = dataset["eval"]
+    except Exception:
+        eval_data = None
+        logger.info("Evaluation dataset is not found")
+
+    if eval_data is None:  # If no eval split exists, create one
+        logger.info("Creating eval split from train data")
+        # Split the train data into 90% train and 10% eval (validation)
+        train_valid_split = train_data.train_test_split(test_size=0.1)
+        train_data = train_valid_split["train"]
+        eval_data = train_valid_split["test"]
+        logger.info(f"Created eval split with {len(eval_data)} examples")
+
+    # Distribute dataset across PyTorchJob workers.
+    RANK = int(os.environ["RANK"])
+    WORLD_SIZE = int(os.environ["WORLD_SIZE"])
+    logger.info(
+        f"Distributed dataset across PyTorchJob workers. WORLD_SIZE: {WORLD_SIZE}, RANK: {RANK}"
+    )
+    if isinstance(train_data, Dataset):
+        train_data = split_dataset_by_node(
+            train_data,
+            rank=RANK,
+            world_size=WORLD_SIZE,
+        )
+    if isinstance(eval_data, Dataset):
+        eval_data = split_dataset_by_node(
+            eval_data,
+            rank=RANK,
+            world_size=WORLD_SIZE,
+        )
+
+    return train_data, eval_data
+
+
+def setup_peft_model(model, lora_config):
+    # Set up the PEFT model
+    lora_config = LoraConfig(**json.loads(lora_config))
+    model.enable_input_require_grads()
+    model = get_peft_model(model, lora_config)
+    return model
+
+
+def train_model(model, transformer_type, train_data, eval_data, tokenizer, train_args):
+    # Setup the Trainer.
+    trainer = Trainer(
+        model=model,
+        train_dataset=train_data,
+        eval_dataset=eval_data,
+        args=train_args,
+    )
+
+    # TODO (andreyvelich): Currently, data collator is supported only for casual LM Transformer.
+    if transformer_type == AutoModelForCausalLM:
+        logger.info("Add data collector for language modeling")
+        logger.info("-" * 40)
+        trainer.data_collator = DataCollatorForLanguageModeling(
+            tokenizer,
+            pad_to_multiple_of=8,
+            mlm=False,
+        )
+
+    # Train the model.
+    trainer.train()
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Script for training a model with PEFT configuration."
+    )
+
+    parser.add_argument("--model_uri", help="model uri")
+    parser.add_argument("--transformer_type", help="model transformer type")
+    parser.add_argument("--model_dir", help="directory containing model")
+    parser.add_argument("--dataset_dir", help="directory containing dataset")
+    parser.add_argument("--lora_config", help="lora_config")
+    parser.add_argument(
+        "--training_parameters", help="hugging face training parameters"
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    logger.info("Starting HuggingFace LLM Trainer")
+    args = parse_arguments()
+    train_args = TrainingArguments(**json.loads(args.training_parameters))
+    transformer_type = getattr(transformers, args.transformer_type)
+
+    logger.info("Setup model and tokenizer")
+    model, tokenizer = setup_model_and_tokenizer(
+        args.model_uri, transformer_type, args.model_dir
+    )
+
+    logger.info("Preprocess dataset")
+    train_data, eval_data = load_and_preprocess_data(
+        args.dataset_dir, transformer_type, tokenizer
+    )
+
+    logger.info("Setup LoRA config for model")
+    model = setup_peft_model(model, args.lora_config)
+
+    logger.info("Start model training")
+    train_model(model, transformer_type, train_data, eval_data, tokenizer, train_args)
+
+    logger.info("Training is complete")

--- a/tests/kfto/core/kfto_training_test.go
+++ b/tests/kfto/core/kfto_training_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	. "github.com/project-codeflare/codeflare-common/support"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kftov1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
+)
+
+func TestPyTorchJobWithCuda(t *testing.T) {
+	test := With(t)
+	cudaBaseImage := GetCudaTrainingImage(test)
+	gpuLabel := "nvidia.com/gpu"
+	runKFTOPyTorchJob(t, cudaBaseImage, gpuLabel, 1)
+}
+
+func TestPyTorchJobWithROCm(t *testing.T) {
+	test := With(t)
+	rocmBaseImage := GetROCmTrainingImage(test)
+	gpuLabel := "amd.com/gpu"
+	runKFTOPyTorchJob(t, rocmBaseImage, gpuLabel, 1)
+}
+
+func runKFTOPyTorchJob(t *testing.T, image string, gpuLabel string, numGpus int) {
+	test := With(t)
+
+	// Create a namespace
+	namespace := GetOrCreateTestNamespace(test)
+
+	// Parse training script
+	trainingScriptPath := "hf_llm_training.py"
+	trainingScript, err := os.ReadFile(trainingScriptPath)
+	if err != nil {
+		test.T().Fatalf("Error reading training script file: %v", err)
+	}
+
+	// Create a ConfigMap with training script
+	configData := map[string][]byte{
+		"hf_llm_training.py": trainingScript,
+	}
+	config := CreateConfigMap(test, namespace, configData)
+
+	// Create PVC for trained model
+	outputPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", corev1.ReadWriteOnce)
+	defer test.Client().Core().CoreV1().PersistentVolumeClaims(namespace).Delete(test.Ctx(), outputPvc.Name, metav1.DeleteOptions{})
+
+	// Create training PyTorch job
+	tuningJob := createKFTOPyTorchJob(test, namespace, *config, gpuLabel, numGpus, outputPvc.Name, image)
+	defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(namespace).Delete(test.Ctx(), tuningJob.Name, *metav1.NewDeleteOptions(0))
+
+	// Make sure the PyTorch job is running
+	test.Eventually(PytorchJob(test, namespace, tuningJob.Name), TestTimeoutDouble).
+		Should(WithTransform(PytorchJobConditionRunning, Equal(corev1.ConditionTrue)))
+
+	// Make sure the PyTorch job succeeded
+	test.Eventually(PytorchJob(test, namespace, tuningJob.Name), TestTimeoutDouble).Should(WithTransform(PytorchJobConditionSucceeded, Equal(corev1.ConditionTrue)))
+	test.T().Logf("PytorchJob %s/%s ran successfully", tuningJob.Namespace, tuningJob.Name)
+
+}
+
+func createKFTOPyTorchJob(test Test, namespace string, config corev1.ConfigMap, gpuLabel string, numGpus int, outputPvcName string, baseImage string) *kftov1.PyTorchJob {
+	tuningJob := &kftov1.PyTorchJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "PyTorchJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "kfto-llm-",
+		},
+		Spec: kftov1.PyTorchJobSpec{
+			PyTorchReplicaSpecs: map[kftov1.ReplicaType]*kftov1.ReplicaSpec{
+				"Master": {
+					Replicas:      Ptr(int32(1)),
+					RestartPolicy: "OnFailure",
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Tolerations: []corev1.Toleration{
+								{
+									Key:      gpuLabel,
+									Operator: corev1.TolerationOpExists,
+								},
+							},
+							InitContainers: []corev1.Container{
+								{
+									Name:            "copy-model",
+									Image:           GetBloomModelImage(),
+									ImagePullPolicy: corev1.PullIfNotPresent,
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "tmp-volume",
+											MountPath: "/tmp",
+										},
+									},
+									Command: []string{"/bin/sh", "-c"},
+									Args:    []string{"mkdir /tmp/model; cp -r /models/bloom-560m /tmp/model"},
+								},
+								{
+									Name:            "copy-dataset",
+									Image:           "registry.access.redhat.com/ubi9/python-311:9.5-1730564330",
+									ImagePullPolicy: corev1.PullIfNotPresent,
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "data-volume",
+											MountPath: "/tmp/dataset",
+										},
+									},
+									Command: []string{
+										"/bin/sh",
+										"-c",
+										`pip install --target /tmp/.local datasets && \
+									HF_HOME=/tmp/.cache PYTHONPATH=/tmp/.local python -c "from datasets import load_dataset; dataset = load_dataset('tatsu-lab/alpaca', split='train[:100]'); dataset.save_to_disk('/tmp/dataset')"`,
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name:  "HF_HOME",
+											Value: "/tmp/.cache",
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name:            "pytorch",
+									Image:           baseImage,
+									ImagePullPolicy: corev1.PullIfNotPresent,
+									Command: []string{
+										"/bin/bash", "-c",
+										`export HF_HOME=/tmp/.cache && \
+										mkdir /tmp/.triton && \
+										export TRITON_CACHE_DIR=/tmp/.triton && \
+										export TOKENIZERS_PARALLELISM=false && \
+										export RANK=0 && \
+										export WORLD_SIZE=1 && \
+										python /etc/config/hf_llm_training.py \
+										--model_uri /tmp/model/bloom-560m \
+										--model_dir /tmp/model/bloom-560m \
+										--dataset_dir /tmp/dataset \
+										--transformer_type AutoModelForCausalLM \
+										--training_parameters '{"output_dir": "/mnt/output", "per_device_train_batch_size": 8, "num_train_epochs": 3, "logging_dir": "/logs", "eval_strategy": "epoch"}' \
+										--lora_config '{"r": 4, "lora_alpha": 16, "lora_dropout": 0.1, "bias": "none"}'`,
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name:  "HF_HOME",
+											Value: "/tmp/.cache",
+										},
+										{
+											Name:  "TRITON_CACHE_DIR",
+											Value: "/tmp/.triton",
+										},
+										{
+											Name:  "RANK",
+											Value: "0",
+										},
+										{
+											Name:  "WORLD_SIZE",
+											Value: "1",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "config-volume",
+											MountPath: "/etc/config",
+										},
+										{
+											Name:      "tmp-volume",
+											MountPath: "/tmp",
+										},
+										{
+											Name:      "output-volume",
+											MountPath: "/mnt/output",
+										},
+										{
+											Name:      "data-volume",
+											MountPath: "tmp/dataset",
+										},
+									},
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:            resource.MustParse("2"),
+											corev1.ResourceMemory:         resource.MustParse("8Gi"),
+											corev1.ResourceName(gpuLabel): resource.MustParse(fmt.Sprint(numGpus)),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:            resource.MustParse("2"),
+											corev1.ResourceMemory:         resource.MustParse("8Gi"),
+											corev1.ResourceName(gpuLabel): resource.MustParse(fmt.Sprint(numGpus)),
+										},
+									},
+									SecurityContext: &corev1.SecurityContext{
+										RunAsNonRoot:           Ptr(true),
+										ReadOnlyRootFilesystem: Ptr(true),
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "config-volume",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: config.Name,
+											},
+										},
+									},
+								},
+								{
+									Name: "tmp-volume",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "data-volume",
+									VolumeSource: corev1.VolumeSource{
+										Ephemeral: &corev1.EphemeralVolumeSource{
+											VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+												Spec: corev1.PersistentVolumeClaimSpec{
+													AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+													Resources: corev1.VolumeResourceRequirements{
+														Requests: corev1.ResourceList{
+															corev1.ResourceStorage: resource.MustParse("2000Gi"),
+														},
+													},
+													VolumeMode: Ptr(corev1.PersistentVolumeFilesystem),
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "output-volume",
+									VolumeSource: corev1.VolumeSource{
+										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+											ClaimName: outputPvcName,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tuningJob, err := test.Client().Kubeflow().KubeflowV1().PyTorchJobs(namespace).Create(test.Ctx(), tuningJob, metav1.CreateOptions{})
+	test.Expect(err).NotTo(HaveOccurred())
+	test.T().Logf("Created PytorchJob %s/%s successfully", tuningJob.Namespace, tuningJob.Name)
+
+	return tuningJob
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
[RHOAIENG-14536](https://issues.redhat.com/browse/RHOAIENG-14536)
[RHOAIENG-14537](https://issues.redhat.com/browse/RHOAIENG-14537)
[RHOAIENG-14568](https://issues.redhat.com/browse/RHOAIENG-14568)

## Description
 - Added an E2E test to cover usage of the CUDA and ROCm training images.
 - Included a [python script taken from the training-operator](https://github.com/kubeflow/training-operator/blob/master/sdk/python/kubeflow/trainer/hf_llm_training.py) for which I have included the apache license and a reference to the location of the original script. I have noted in a comment where the script has been altered.
 - Added environment variables so that the test can be used for both CUDA and ROCm images.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have run the test with the CUDA image on a rosa cluster.  (Plan to test ROCm image next on AMD cluster.)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
