### PR TITLE
Adjust 'go.embed' to accept python files

### DIFF
--- a/tests/kfto/core/kfto_training_test.go
+++ b/tests/kfto/core/kfto_training_test.go
@@ -46,7 +46,7 @@ func runKFTOPyTorchJob(t *testing.T, image string, gpuLabel string, numGpus int)
 
 	// Create a ConfigMap with training script
 	configData := map[string][]byte{
-		"hf_llm_training.py": ReadFileExt(test, "hf_llm_training.py"),
+		"hf_llm_training.py": ReadFile(test, "hf_llm_training.py"),
 	}
 	config := CreateConfigMap(test, namespace, configData)
 

--- a/tests/kfto/core/support.go
+++ b/tests/kfto/core/support.go
@@ -19,10 +19,8 @@ package core
 import (
 	"embed"
 	"fmt"
-	"os"
 	"time"
 
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	. "github.com/project-codeflare/codeflare-common/support"
 
@@ -34,19 +32,13 @@ import (
 )
 
 //go:embed *.json
+//go:embed *.py
 var files embed.FS
 
 func ReadFile(t Test, fileName string) []byte {
 	t.T().Helper()
 	file, err := files.ReadFile(fileName)
 	t.Expect(err).NotTo(HaveOccurred())
-	return file
-}
-
-func ReadFileExt(t Test, fileName string) []byte {
-	t.T().Helper()
-	file, err := os.ReadFile(fileName)
-	t.Expect(err).NotTo(gomega.HaveOccurred())
 	return file
 }
 


### PR DESCRIPTION

## Description
This PR adjusts 'go.embed' to accept python files and removes the "ReadExt" method

## How Has This Been Tested?
Tested the changes manually by running the KFTO tests locally

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
