### PR TITLE
Update kfto test to utilise alpaca dataset image to access dataset instead of downloading it from huggingface

### DIFF
--- a/tests/kfto/core/hf_llm_training.py
+++ b/tests/kfto/core/hf_llm_training.py
@@ -85,11 +85,10 @@ def load_and_preprocess_data(dataset_file, transformer_type, tokenizer):
 
         logger.info("Tokenize dataset")
         # TODO (andreyvelich): Discuss how user should set the tokenizer function.
-        num_cores = os.cpu_count()
         dataset = dataset.map(
             lambda x: tokenizer(x["output"], padding=True, truncation=True, max_length=128),
             batched=True,
-            num_proc=num_cores
+            keep_in_memory=True
         )
 
     # Check if dataset contains `train` key. Otherwise, load full dataset to train_data.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
[RHOAIENG-16198](https://issues.redhat.com/browse/RHOAIENG-16198)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Update test to utilise alpaca dataset image to access dataset instead of downloading it from huggingface
- Updated training script to use sequential dataset pre-processing instead of parallel to avoid MD5 hash checks

Same approach tested locally using data copied from [alpaca-dataset image](quay.io/ksuta/alpaca-dataset@sha256:2e90f631180c7b2c916f9569b914b336b612e8ae86efad82546adc5c9fcbbb8d) : 

![image](https://github.com/user-attachments/assets/5caa081f-c626-4cf7-bcc5-fe2d9b499711)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
