### PR TITLE
Generate a smaller dataset

### DIFF
--- a/images/dataset/alpaca/Dockerfile
+++ b/images/dataset/alpaca/Dockerfile
@@ -11,6 +11,7 @@ RUN python convert_replicate.py alpaca_data_formatted.json alpaca_data_half.json
 RUN python convert_replicate.py alpaca_data_formatted.json alpaca_data_quarter.json 0.25
 RUN python convert_replicate.py alpaca_data_formatted.json alpaca_data_tenth.json 0.1
 RUN python convert_replicate.py alpaca_data_formatted.json alpaca_data_hundredth.json 0.01
+RUN python convert_replicate.py alpaca_data_formatted.json alpaca_data_thousandth.json 0.001
 
 FROM registry.access.redhat.com/ubi9:latest
 WORKDIR /dataset
@@ -22,3 +23,4 @@ COPY --from=builder /dataset/alpaca_data_half.json alpaca_data_half.json
 COPY --from=builder /dataset/alpaca_data_quarter.json alpaca_data_quarter.json
 COPY --from=builder /dataset/alpaca_data_tenth.json alpaca_data_tenth.json
 COPY --from=builder /dataset/alpaca_data_hundredth.json alpaca_data_hundredth.json
+COPY --from=builder /dataset/alpaca_data_thousandth.json alpaca_data_thousandth.json


### PR DESCRIPTION
Related to [RHOAIENG-16556](https://issues.redhat.com/browse/RHOAIENG-16556)

## Description
Generate a smaller dataset which is needed to execute KFTO training tests with CPU in limited time

## How Has This Been Tested?
Build locally and pushed the image to quay `quay.io/shchugh/alpaca-dataset?tab=tags&tag=amd64`

## Merge criteria:


- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
