### PR TITLE
Add KFTO Training tests which run with CPUs only

### DIFF
--- a/tests/kfto/core/environment.go
+++ b/tests/kfto/core/environment.go
@@ -56,7 +56,7 @@ func GetBloomModelImage() string {
 }
 
 func GetAlpacaDatasetImage() string {
-	return lookupEnvOrDefault(alpacaDatasetImageEnvVar, "quay.io/ksuta/alpaca-dataset@sha256:2e90f631180c7b2c916f9569b914b336b612e8ae86efad82546adc5c9fcbbb8d")
+	return lookupEnvOrDefault(alpacaDatasetImageEnvVar, "quay.io/ksuta/alpaca-dataset@sha256:857508acdb44aa852d68622876a0c38c3e22db893ea3a0b09a5832b27e5fa075")
 }
 
 func GetMinioCliImage() string {

--- a/tests/kfto/core/kfto_training_test.go
+++ b/tests/kfto/core/kfto_training_test.go
@@ -30,15 +30,23 @@ import (
 	kftov1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 )
 
-func TestPyTorchJobWithCuda(t *testing.T) {
-	runKFTOPyTorchJob(t, GetCudaTrainingImage(), "nvidia.com/gpu", 1)
+func TestPyTorchJobWithCudaGpu(t *testing.T) {
+	runKFTOPyTorchJob(t, GetCudaTrainingImage(), "nvidia.com/gpu", "alpaca_data_hundredth.json", 1, 2, "8Gi")
 }
 
-func TestPyTorchJobWithROCm(t *testing.T) {
-	runKFTOPyTorchJob(t, GetROCmTrainingImage(), "amd.com/gpu", 1)
+func TestPyTorchJobWithCudaCpu(t *testing.T) {
+	runKFTOPyTorchJob(t, GetCudaTrainingImage(), "nvidia.com/gpu", "alpaca_data_thousandth.json", 0, 12, "12Gi")
 }
 
-func runKFTOPyTorchJob(t *testing.T, image string, gpuLabel string, numGpus int) {
+func TestPyTorchJobWithROCmGpu(t *testing.T) {
+	runKFTOPyTorchJob(t, GetROCmTrainingImage(), "amd.com/gpu", "alpaca_data_hundredth.json", 1, 2, "8Gi")
+}
+
+func TestPyTorchJobWithROCmCpu(t *testing.T) {
+	runKFTOPyTorchJob(t, GetROCmTrainingImage(), "amd.com/gpu", "alpaca_data_thousandth.json", 0, 12, "12Gi")
+}
+
+func runKFTOPyTorchJob(t *testing.T, image string, gpuLabel string, datasetSize string, numGpus int, numCpus int, memory string) {
 	test := With(t)
 
 	// Create a namespace
@@ -55,7 +63,7 @@ func runKFTOPyTorchJob(t *testing.T, image string, gpuLabel string, numGpus int)
 	defer test.Client().Core().CoreV1().PersistentVolumeClaims(namespace).Delete(test.Ctx(), outputPvc.Name, metav1.DeleteOptions{})
 
 	// Create training PyTorch job
-	tuningJob := createKFTOPyTorchJob(test, namespace, *config, gpuLabel, numGpus, outputPvc.Name, image)
+	tuningJob := createKFTOPyTorchJob(test, namespace, *config, gpuLabel, datasetSize, numGpus, numCpus, memory, outputPvc.Name, image)
 	defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(namespace).Delete(test.Ctx(), tuningJob.Name, *metav1.NewDeleteOptions(0))
 
 	// Make sure the PyTorch job is running
@@ -68,7 +76,7 @@ func runKFTOPyTorchJob(t *testing.T, image string, gpuLabel string, numGpus int)
 
 }
 
-func createKFTOPyTorchJob(test Test, namespace string, config corev1.ConfigMap, gpuLabel string, numGpus int, outputPvcName string, baseImage string) *kftov1.PyTorchJob {
+func createKFTOPyTorchJob(test Test, namespace string, config corev1.ConfigMap, gpuLabel string, datasetSize string, numGpus int, numCpus int, memory string, outputPvcName string, baseImage string) *kftov1.PyTorchJob {
 	tuningJob := &kftov1.PyTorchJob{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
@@ -114,8 +122,14 @@ func createKFTOPyTorchJob(test Test, namespace string, config corev1.ConfigMap, 
 											MountPath: "/tmp",
 										},
 									},
+									Env: []corev1.EnvVar{
+										{
+											Name:  "DATASET_SIZE",
+											Value: datasetSize,
+										},
+									},
 									Command: []string{"/bin/sh", "-c"},
-									Args:    []string{"mkdir /tmp/all_datasets; cp -r /dataset/* /tmp/all_datasets;ls /tmp/all_datasets"},
+									Args:    []string{"mkdir /tmp/all_datasets; cp -r /dataset/$(DATASET_SIZE) /tmp/all_datasets/alpaca_data.json"},
 								},
 							},
 							Containers: []corev1.Container{
@@ -128,7 +142,7 @@ func createKFTOPyTorchJob(test Test, namespace string, config corev1.ConfigMap, 
 										`python /etc/config/hf_llm_training.py \
 										--model_uri /tmp/model/bloom-560m \
 										--model_dir /tmp/model/bloom-560m \
-										--dataset_file /tmp/all_datasets/alpaca_data_hundredth.json \
+										--dataset_file /tmp/all_datasets/alpaca_data.json \
 										--transformer_type AutoModelForCausalLM \
 										--training_parameters '{"output_dir": "/mnt/output", "per_device_train_batch_size": 8, "num_train_epochs": 3, "logging_dir": "/logs", "eval_strategy": "epoch"}' \
 										--lora_config '{"r": 4, "lora_alpha": 16, "lora_dropout": 0.1, "bias": "none"}'`,
@@ -163,13 +177,13 @@ func createKFTOPyTorchJob(test Test, namespace string, config corev1.ConfigMap, 
 									},
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:            resource.MustParse("2"),
-											corev1.ResourceMemory:         resource.MustParse("8Gi"),
+											corev1.ResourceCPU:            resource.MustParse(fmt.Sprint(numCpus)),
+											corev1.ResourceMemory:         resource.MustParse(memory),
 											corev1.ResourceName(gpuLabel): resource.MustParse(fmt.Sprint(numGpus)),
 										},
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:            resource.MustParse("2"),
-											corev1.ResourceMemory:         resource.MustParse("8Gi"),
+											corev1.ResourceCPU:            resource.MustParse(fmt.Sprint(numCpus)),
+											corev1.ResourceMemory:         resource.MustParse(memory),
 											corev1.ResourceName(gpuLabel): resource.MustParse(fmt.Sprint(numGpus)),
 										},
 									},


### PR DESCRIPTION
Closes [RHOAIENG-16556](https://issues.redhat.com/browse/RHOAIENG-16556)

## Description
This PR adds KFTO Training tests to run with CPUs only with smaller dataset to execute tests in limited time so that these tests can be used in downstream testing

## How Has This Been Tested?
Tested the KFTO traininf tests locally

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
