### PR TITLE
Update KFTO MNIST muti-node/multi-gpu test to utilise multiple GPUs c…

### DIFF
--- a/tests/kfto/kfto_mnist_training_test.go
+++ b/tests/kfto/kfto_mnist_training_test.go
@@ -30,27 +30,30 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestPyTorchJobMnistMultiNodeCpu(t *testing.T) {
-	runKFTOPyTorchMnistJob(t, 0, 2, "", GetCudaTrainingImage(), "resources/requirements.txt")
+func TestPyTorchJobMnistMultiNodeSingleCpu(t *testing.T) {
+	runKFTOPyTorchMnistJob(t, 0, 2, 1, "", GetCudaTrainingImage(), "resources/requirements.txt")
+}
+func TestPyTorchJobMnistMultiNodeMultiCpu(t *testing.T) {
+	runKFTOPyTorchMnistJob(t, 0, 2, 2, "", GetCudaTrainingImage(), "resources/requirements.txt")
 }
 
-func TestPyTorchJobMnistMultiNodeWithCuda(t *testing.T) {
-	runKFTOPyTorchMnistJob(t, 1, 1, "nvidia.com/gpu", GetCudaTrainingImage(), "resources/requirements.txt")
-}
-
-func TestPyTorchJobMnistMultiNodeWithROCm(t *testing.T) {
-	runKFTOPyTorchMnistJob(t, 1, 1, "amd.com/gpu", GetROCmTrainingImage(), "resources/requirements-rocm.txt")
+func TestPyTorchJobMnistMultiNodeSingleGpuWithCuda(t *testing.T) {
+	runKFTOPyTorchMnistJob(t, 1, 1, 1, "nvidia.com/gpu", GetCudaTrainingImage(), "resources/requirements.txt")
 }
 
 func TestPyTorchJobMnistMultiNodeMultiGpuWithCuda(t *testing.T) {
-	runKFTOPyTorchMnistJob(t, 2, 1, "nvidia.com/gpu", GetCudaTrainingImage(), "resources/requirements.txt")
+	runKFTOPyTorchMnistJob(t, 2, 1, 2, "nvidia.com/gpu", GetCudaTrainingImage(), "resources/requirements.txt")
+}
+
+func TestPyTorchJobMnistMultiNodeSingleGpuWithROCm(t *testing.T) {
+	runKFTOPyTorchMnistJob(t, 1, 1, 1, "amd.com/gpu", GetROCmTrainingImage(), "resources/requirements-rocm.txt")
 }
 
 func TestPyTorchJobMnistMultiNodeMultiGpuWithROCm(t *testing.T) {
-	runKFTOPyTorchMnistJob(t, 2, 1, "amd.com/gpu", GetROCmTrainingImage(), "resources/requirements-rocm.txt")
+	runKFTOPyTorchMnistJob(t, 2, 1, 2, "amd.com/gpu", GetROCmTrainingImage(), "resources/requirements-rocm.txt")
 }
 
-func runKFTOPyTorchMnistJob(t *testing.T, numGpus int, workerReplicas int, gpuLabel string, image string, requirementsFile string) {
+func runKFTOPyTorchMnistJob(t *testing.T, totalNumGpus int, workerReplicas int, numProcPerNode int, gpuLabel string, image string, requirementsFile string) {
 	test := With(t)
 
 	// Create a namespace
@@ -59,7 +62,7 @@ func runKFTOPyTorchMnistJob(t *testing.T, numGpus int, workerReplicas int, gpuLa
 	mnist := ReadFile(test, "resources/mnist.py")
 	requirementsFileName := ReadFile(test, requirementsFile)
 
-	if numGpus > 0 {
+	if totalNumGpus > 0 {
 		mnist = bytes.Replace(mnist, []byte("accelerator=\"has to be specified\""), []byte("accelerator=\"gpu\""), 1)
 	} else {
 		mnist = bytes.Replace(mnist, []byte("accelerator=\"has to be specified\""), []byte("accelerator=\"cpu\""), 1)
@@ -74,7 +77,7 @@ func runKFTOPyTorchMnistJob(t *testing.T, numGpus int, workerReplicas int, gpuLa
 	defer test.Client().Core().CoreV1().PersistentVolumeClaims(namespace.Name).Delete(test.Ctx(), outputPvc.Name, metav1.DeleteOptions{})
 
 	// Create training PyTorch job
-	tuningJob := createKFTOPyTorchMnistJob(test, namespace.Name, *config, gpuLabel, numGpus, workerReplicas, outputPvc.Name, image)
+	tuningJob := createKFTOPyTorchMnistJob(test, namespace.Name, *config, gpuLabel, totalNumGpus, workerReplicas, numProcPerNode, outputPvc.Name, image)
 	defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(namespace.Name).Delete(test.Ctx(), tuningJob.Name, *metav1.NewDeleteOptions(0))
 
 	// Make sure the PyTorch job is running
@@ -87,11 +90,11 @@ func runKFTOPyTorchMnistJob(t *testing.T, numGpus int, workerReplicas int, gpuLa
 
 }
 
-func createKFTOPyTorchMnistJob(test Test, namespace string, config corev1.ConfigMap, gpuLabel string, numGpus int, workerReplicas int, outputPvcName string, baseImage string) *kftov1.PyTorchJob {
+func createKFTOPyTorchMnistJob(test Test, namespace string, config corev1.ConfigMap, gpuLabel string, totalNumGpus int, workerReplicas int, numProcPerNode int, outputPvcName string, baseImage string) *kftov1.PyTorchJob {
 	var useGPU = false
 	var backend string
 
-	if numGpus > 0 {
+	if totalNumGpus > 0 {
 		useGPU = true
 		backend = "nccl"
 	} else {
@@ -108,13 +111,14 @@ func createKFTOPyTorchMnistJob(test Test, namespace string, config corev1.Config
 		},
 		Spec: kftov1.PyTorchJobSpec{
 			PyTorchReplicaSpecs: map[kftov1.ReplicaType]*kftov1.ReplicaSpec{
-				"Master": {
+				kftov1.PyTorchJobReplicaTypeMaster: {
 					Replicas:      Ptr(int32(1)),
 					RestartPolicy: kftov1.RestartPolicyOnFailure,
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"app": "kfto-mnist",
+								"app":  "kfto-mnist",
+								"role": "master",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -141,7 +145,7 @@ func createKFTOPyTorchMnistJob(test Test, namespace string, config corev1.Config
 										"/bin/bash", "-c",
 										fmt.Sprintf(`mkdir -p /tmp/lib && export PYTHONPATH=$PYTHONPATH:/tmp/lib && \
 										pip install --no-cache-dir -r /mnt/files/requirements.txt --target=/tmp/lib && \
-										python /mnt/files/mnist.py --epochs 3 --save-model --output-path /mnt/output --backend %s`, backend),
+										torchrun --nproc_per_node=%d /mnt/files/mnist.py --epochs 7 --save_every 2 --batch_size 64 --lr 0.0005 --snapshot_path "mnist_snapshot.pt" --backend %s`, numProcPerNode, backend),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -159,7 +163,7 @@ func createKFTOPyTorchMnistJob(test Test, namespace string, config corev1.Config
 									},
 									Resources: corev1.ResourceRequirements{
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", numProcPerNode)),
 											corev1.ResourceMemory: resource.MustParse("6Gi"),
 										},
 									},
@@ -195,13 +199,14 @@ func createKFTOPyTorchMnistJob(test Test, namespace string, config corev1.Config
 						},
 					},
 				},
-				"Worker": {
+				kftov1.PyTorchJobReplicaTypeWorker: {
 					Replicas:      Ptr(int32(workerReplicas)),
 					RestartPolicy: kftov1.RestartPolicyOnFailure,
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"app": "kfto-mnist",
+								"app":  "kfto-mnist",
+								"role": "worker",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -228,7 +233,7 @@ func createKFTOPyTorchMnistJob(test Test, namespace string, config corev1.Config
 										"/bin/bash", "-c",
 										fmt.Sprintf(`mkdir -p /tmp/lib && export PYTHONPATH=$PYTHONPATH:/tmp/lib && \
 										pip install --no-cache-dir -r /mnt/files/requirements.txt --target=/tmp/lib && \
-										python /mnt/files/mnist.py --epochs 3 --save-model --backend %s`, backend),
+										torchrun --nproc_per_node=%d /mnt/files/mnist.py --epochs 7 --save_every 2 --batch_size 64 --lr 0.0005 --snapshot_path "mnist_snapshot.pt" --backend %s`, numProcPerNode, backend),
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -242,7 +247,7 @@ func createKFTOPyTorchMnistJob(test Test, namespace string, config corev1.Config
 									},
 									Resources: corev1.ResourceRequirements{
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
+											corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", numProcPerNode)),
 											corev1.ResourceMemory: resource.MustParse("6Gi"),
 										},
 									},
@@ -276,19 +281,40 @@ func createKFTOPyTorchMnistJob(test Test, namespace string, config corev1.Config
 
 	if useGPU {
 		// Update resource lists for GPU (NVIDIA/ROCm) usecase
-		tuningJob.Spec.PyTorchReplicaSpecs["Master"].Template.Spec.Containers[0].Resources.Limits[corev1.ResourceName(gpuLabel)] = resource.MustParse(fmt.Sprint(numGpus))
-		tuningJob.Spec.PyTorchReplicaSpecs["Worker"].Template.Spec.Containers[0].Resources.Limits[corev1.ResourceName(gpuLabel)] = resource.MustParse(fmt.Sprint(numGpus))
+		tuningJob.Spec.PyTorchReplicaSpecs["Master"].Template.Spec.Containers[0].Resources.Limits[corev1.ResourceName(gpuLabel)] = resource.MustParse(fmt.Sprint(totalNumGpus))
+		tuningJob.Spec.PyTorchReplicaSpecs["Worker"].Template.Spec.Containers[0].Resources.Limits[corev1.ResourceName(gpuLabel)] = resource.MustParse(fmt.Sprint(totalNumGpus))
+
+		tuningJob.Spec.PyTorchReplicaSpecs[kftov1.PyTorchJobReplicaTypeMaster].Template.Spec.Containers[0].Command = []string{
+			"/bin/bash", "-c",
+			fmt.Sprintf(`mkdir -p /tmp/lib && export PYTHONPATH=$PYTHONPATH:/tmp/lib && \
+			pip install --no-cache-dir -r /mnt/files/requirements.txt --target=/tmp/lib && \
+			torchrun --nproc_per_node=%d /mnt/files/mnist.py --epochs 7 --save_every 2 --batch_size 128 --lr 0.001 --snapshot_path "mnist_snapshot.pt" --backend %s`, numProcPerNode, backend),
+		}
+		tuningJob.Spec.PyTorchReplicaSpecs[kftov1.MPIJobReplicaTypeWorker].Template.Spec.Containers[0].Command = []string{
+			"/bin/bash", "-c",
+			fmt.Sprintf(`mkdir -p /tmp/lib && export PYTHONPATH=$PYTHONPATH:/tmp/lib && \
+			pip install --no-cache-dir -r /mnt/files/requirements.txt --target=/tmp/lib && \
+			torchrun --nproc_per_node=%d /mnt/files/mnist.py --epochs 7 --save_every 2 --batch_size 128 --lr 0.001 --snapshot_path "mnist_snapshot.pt" --backend %s`, numProcPerNode, backend),
+		}
 
 		tuningJob.Spec.PyTorchReplicaSpecs["Master"].Template.Spec.Containers[0].Env = []corev1.EnvVar{
 			{
 				Name:  "NCCL_DEBUG",
 				Value: "INFO",
 			},
+			{
+				Name:  "TORCH_DISTRIBUTED_DEBUG",
+				Value: "DETAIL",
+			},
 		}
 		tuningJob.Spec.PyTorchReplicaSpecs["Worker"].Template.Spec.Containers[0].Env = []corev1.EnvVar{
 			{
 				Name:  "NCCL_DEBUG",
 				Value: "INFO",
+			},
+			{
+				Name:  "TORCH_DISTRIBUTED_DEBUG",
+				Value: "DETAIL",
 			},
 		}
 

--- a/tests/kfto/kfto_training_test.go
+++ b/tests/kfto/kfto_training_test.go
@@ -98,7 +98,7 @@ func runKFTOPyTorchJob(t *testing.T, image string, gpu Gpu, numGpus, numberOfWor
 					And(
 						HaveLen(numGpus),
 						ContainElement(
-							// Check that at lest some GPU was utilized on more than 50%
+							// Check that at least some GPU was utilized on more than 50%
 							HaveField("Value", BeNumerically(">", 50)),
 						),
 					),

--- a/tests/kfto/kfto_training_test.go
+++ b/tests/kfto/kfto_training_test.go
@@ -62,7 +62,7 @@ func TestPyTorchJobMultiNodeMultiGpuWithROCm(t *testing.T) {
 	runKFTOPyTorchJob(t, GetROCmTrainingImage(), AMD, 2, 1)
 }
 
-func runKFTOPyTorchJob(t *testing.T, image string, gpu Gpu, numGpus, numberOfWorkerNodes int) {
+func runKFTOPyTorchJob(t *testing.T, image string, gpu Accelerator, numGpus, numberOfWorkerNodes int) {
 	test := With(t)
 
 	// Create a namespace
@@ -112,7 +112,7 @@ func runKFTOPyTorchJob(t *testing.T, image string, gpu Gpu, numGpus, numberOfWor
 	test.T().Logf("PytorchJob %s/%s ran successfully", tuningJob.Namespace, tuningJob.Name)
 }
 
-func createKFTOPyTorchJob(test Test, namespace string, config corev1.ConfigMap, gpu Gpu, numGpus, numberOfWorkerNodes int, outputPvcName string, baseImage string) *kftov1.PyTorchJob {
+func createKFTOPyTorchJob(test Test, namespace string, config corev1.ConfigMap, gpu Accelerator, numGpus, numberOfWorkerNodes int, outputPvcName string, baseImage string) *kftov1.PyTorchJob {
 	tuningJob := &kftov1.PyTorchJob{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),

--- a/tests/kfto/support.go
+++ b/tests/kfto/support.go
@@ -36,6 +36,7 @@ type Gpu struct {
 var (
 	NVIDIA = Gpu{ResourceLabel: "nvidia.com/gpu", PrometheusGpuUtilizationLabel: "DCGM_FI_DEV_GPU_UTIL"}
 	AMD    = Gpu{ResourceLabel: "amd.com/gpu"}
+	CPU    = Gpu{ResourceLabel: "cpu"}
 )
 
 //go:embed resources/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Updated training script to utilise Multi-Node/Multi-GPU scenario properly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
![image](https://github.com/user-attachments/assets/f8496bc3-ace4-4783-b155-3f691665d950)

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------

Following tests are executed on a cluster having NVIDIA GPUs : 

TestPyTorchJobMnistMultiNodeSingleCpu - 3m 33s (time taken to execute) 
- [kfto-mnist-qmxdx-master-0-pytorch.log](https://github.com/user-attachments/files/18377894/kfto-mnist-qmxdx-master-0-pytorch.log)
- [kfto-mnist-qmxdx-worker-0-pytorch.log](https://github.com/user-attachments/files/18377893/kfto-mnist-qmxdx-worker-0-pytorch.log)
- [kfto-mnist-qmxdx-worker-1-pytorch.log](https://github.com/user-attachments/files/18377890/kfto-mnist-qmxdx-worker-1-pytorch.log)

TestPyTorchJobMnistMultiNodeMultiCpu - 2m 36s
- [kfto-mnist-rqf89-master-0-pytorch.log](https://github.com/user-attachments/files/18377919/kfto-mnist-rqf89-master-0-pytorch.log)
- [kfto-mnist-rqf89-worker-0-pytorch.log](https://github.com/user-attachments/files/18377918/kfto-mnist-rqf89-worker-0-pytorch.log)
- [kfto-mnist-rqf89-worker-1-pytorch.log](https://github.com/user-attachments/files/18377916/kfto-mnist-rqf89-worker-1-pytorch.log)

TestPyTorchJobMnistMultiNodeSingleGpuWithCuda - 2m 35s
- [kfto-mnist-92m5v-master-0-pytorch.log](https://github.com/user-attachments/files/18377876/kfto-mnist-92m5v-master-0-pytorch.log)
- [kfto-mnist-92m5v-worker-0-pytorch.log](https://github.com/user-attachments/files/18377874/kfto-mnist-92m5v-worker-0-pytorch.log)

TestPyTorchJobMnistMultiNodeMultiGpuWithCuda - 2m 16s

- [kfto-mnist-lrmtv-master-0-pytorch.log](https://github.com/user-attachments/files/18377952/kfto-mnist-lrmtv-master-0-pytorch.log)
- [kfto-mnist-lrmtv-worker-0-pytorch.log](https://github.com/user-attachments/files/18377950/kfto-mnist-lrmtv-worker-0-pytorch.log)

-----------------------------------------------------------------------------------------------------------------------------------------------------------------

Following tests are executed on a cluster having AMD GPUs : 

![image](https://github.com/user-attachments/assets/9e2915ed-9a4a-4fd0-8235-78ae7756a969)


TestPyTorchJobMnistMultiNodeSingleCpu - 3m 45s

- [kfto-mnist-8v9qq-master-0-pytorch.log](https://github.com/user-attachments/files/18378819/kfto-mnist-8v9qq-master-0-pytorch.log) 
- [kfto-mnist-8v9qq-worker-0-pytorch.log](https://github.com/user-attachments/files/18378818/kfto-mnist-8v9qq-worker-0-pytorch.log)
- [kfto-mnist-8v9qq-worker-1-pytorch.log](https://github.com/user-attachments/files/18378817/kfto-mnist-8v9qq-worker-1-pytorch.log)

TestPyTorchJobMnistMultiNodeMultiCpu - 2m 42s

- [kfto-mnist-phpwm-master-0-pytorch.log](https://github.com/user-attachments/files/18395301/kfto-mnist-phpwm-master-0-pytorch.log)
- [kfto-mnist-phpwm-worker-0-pytorch.log](https://github.com/user-attachments/files/18395300/kfto-mnist-phpwm-worker-0-pytorch.log)
- [kfto-mnist-phpwm-worker-1-pytorch.log](https://github.com/user-attachments/files/18395298/kfto-mnist-phpwm-worker-1-pytorch.log)

TestPyTorchJobMnistMultiNodeSingleGpuWithROCm - 4m 18s

- [kfto-mnist-9nbsj-master-0-pytorch.log](https://github.com/user-attachments/files/18396482/kfto-mnist-9nbsj-master-0-pytorch.log)
- [kfto-mnist-9nbsj-worker-0-pytorch.log](https://github.com/user-attachments/files/18396481/kfto-mnist-9nbsj-worker-0-pytorch.log)

TestPyTorchJobMnistMultiNodeMultiGpuWithROCm - 3m 8s

- [kfto-mnist-bv4th-master-0-pytorch.log](https://github.com/user-attachments/files/18395313/kfto-mnist-bv4th-master-0-pytorch.log)
- [kfto-mnist-bv4th-worker-0-pytorch.log](https://github.com/user-attachments/files/18395310/kfto-mnist-bv4th-worker-0-pytorch.log)


--------------------------------------------------------------------------------------------------------------------------------------------------------------------

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
