### PR TITLE
Add Dockerfile for running tests in CI

### DIFF
--- a/images/tests/Dockerfile
+++ b/images/tests/Dockerfile
@@ -1,6 +1,8 @@
 # Use the official Go image as a base image
 FROM golang:1.21
 
+ENV KUBECONFIG=/distributed-workloads/tests/.kube/config
+
 # Set the working directory inside the container
 WORKDIR /distributed-workloads
 

--- a/images/tests/Dockerfile
+++ b/images/tests/Dockerfile
@@ -1,0 +1,21 @@
+# Use the official Go image as a base image
+FROM golang:1.21
+
+# Set the working directory inside the container
+WORKDIR /distributed-workloads
+
+# Copy the go mod and sum files
+COPY go.mod go.sum ./
+
+# Download all dependencies
+RUN go mod download && \
+    go install gotest.tools/gotestsum@latest
+    # go install github.com/jstemmer/go-junit-report/v2@latest
+
+WORKDIR /distributed-workloads/tests
+
+# Copy the source from the current directory to the working directory inside the container
+COPY tests/ .
+
+# Command to run the tests
+ENTRYPOINT [ "gotestsum"]

--- a/images/tests/Dockerfile
+++ b/images/tests/Dockerfile
@@ -12,7 +12,6 @@ COPY go.mod go.sum ./
 # Download all dependencies
 RUN go mod download && \
     go install gotest.tools/gotestsum@latest
-    # go install github.com/jstemmer/go-junit-report/v2@latest
 
 WORKDIR /distributed-workloads/tests
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Creating a Dockerfile to build an image which will contain GoLang dependencies and the tests. Besides the dependencies defined in the go.mod, the dockerfile is adding `gotestsum` pkg (https://github.com/gotestyourself/gotestsum) which provides more features for running tests, like generation of junit reports needed for the integration with CI and reporting systems.

Note: setting the working directory to `distributed-workloads/tests` because `gotestsum` runs by default from the current directory (`./...`). Alternatively it is possible to set up the folder to run in 2 ways:
1. setting TEST_DIRECTORY env variable - _it seems to take always precedence_
2. using go test command (i.e., gotestsum -- ./tests) - _the syntax is not very comfortable_
However, both 1 and 2 poses issue when we want to override the folder for any reasons.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. build and push the image to my registry repository
2. run the image from my terminal
3. run the image from our CI

CMD: `podman run --rm   -v ./results:/distributed-workloads/tests/results:Z -v ${kubeconfigPath}:/distributed-workloads/tests/.kube/config:Z <image:tag> --junitfile results/results.xml -- ./... -run=TestPyTorchJobMnistMultiNodeSingleCpu`


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
