### PR TITLE
Upgrade AMD Ray runtime image to ROCm v6.2.4

### DIFF
--- a/.tekton/ray-rocm-push.yaml
+++ b/.tekton/ray-rocm-push.yaml
@@ -24,9 +24,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/modh/ray:2.35.0-py311-rocm61
+    value: quay.io/modh/ray:2.35.0-py311-rocm62
   - name: additional-tag
-    value: 2.35.0-py311-rocm61-{{revision}}
+    value: 2.35.0-py311-rocm62-{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/images/runtime/ray/rocm/Dockerfile
+++ b/images/runtime/ray/rocm/Dockerfile
@@ -1,9 +1,9 @@
 ARG PYTHON_VERSION=311
-ARG IMAGE_TAG=1-77.1726664316
+ARG IMAGE_TAG=9.5-1737537151
 
 FROM registry.access.redhat.com/ubi9/python-${PYTHON_VERSION}:${IMAGE_TAG}
 
-LABEL name="ray-ubi9-py311-rocm61" \
+LABEL name="ray-ubi9-py311-rocm62" \
       summary="ROCm Python 3.11 image based on UBI9 for Ray" \
       description="ROCm Python 3.11 image based on UBI9 for Ray" \
       io.k8s.display-name="ROCm Python 3.11 base image for Ray" \
@@ -14,8 +14,8 @@ LABEL name="ray-ubi9-py311-rocm61" \
 USER 0
 WORKDIR /opt/app-root/bin
 
-ARG ROCM_VERSION=6.1.2
-ARG AMDGPU_VERSION=6.1.2
+ARG ROCM_VERSION=6.2.4
+ARG AMDGPU_VERSION=6.2.4
 
 RUN <<EOF
 cat <<EOD > /etc/yum.repos.d/rocm.repo
@@ -37,7 +37,7 @@ gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
 EOD
 EOF
 
-RUN yum -y install rocm && yum clean all && rm -rf /var/cache/yum
+RUN yum install -y rocm-developer-tools rocm-ml-sdk rocm-opencl-sdk rocm-openmp-sdk rocm-utils && yum clean all && rm -rf /var/cache/yum
 
 # Install Python packages
 


### PR DESCRIPTION
Closes [RHOAIENG-16891](https://issues.redhat.com/browse/RHOAIENG-16891)

## Description
Upgrade AMD Ray runtime image to ROCm v6.2.4

## How Has This Been Tested?
Tested the changes by building the image locally and pushing to my quay repo and then successfully executed the `TestMnistRayROCmGpu` with the new image


## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
