### PR TITLE
Upgrade AMD Training operator runtime image to ROCm v6.2.4

### DIFF
--- a/.tekton/training-rocm-push.yaml
+++ b/.tekton/training-rocm-push.yaml
@@ -24,9 +24,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/modh/training:py311-rocm61-torch241
+    value: quay.io/modh/training:py311-rocm62-torch241
   - name: additional-tag
-    value: py311-rocm61-torch241-{{revision}}
+    value: py311-rocm62-torch241-{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/images/runtime/training/rocm/Dockerfile
+++ b/images/runtime/training/rocm/Dockerfile
@@ -1,15 +1,15 @@
 ## Global Args ######################################################
-ARG IMAGE_TAG=1-77.1729776556
+ARG IMAGE_TAG=9.5-1737537151
 ARG PYTHON_VERSION=311
 
 # use UBI9 latest
 FROM registry.access.redhat.com/ubi9/python-${PYTHON_VERSION}:${IMAGE_TAG} AS base
 
-LABEL name="training:py311-rocm61-torch241" \
-      summary="ROCm 6.1 Python 3.11 PyTorch 2.4.1 image based on UBI9 for Training" \
-      description="ROCm 6.1 Python 3.11 PyTorch 2.4.1 image based on UBI9 for Training" \
-      io.k8s.display-name="ROCm 6.1 Python 3.11 PyTorch 2.4.1 base image for Training" \
-      io.k8s.description="ROCm 6.1 Python 3.11 PyTorch 2.4.1 image based on UBI9 for Training" \
+LABEL name="training:py311-rocm62-torch241" \
+      summary="ROCm 6.2 Python 3.11 PyTorch 2.4.1 image based on UBI9 for Training" \
+      description="ROCm 6.2 Python 3.11 PyTorch 2.4.1 image based on UBI9 for Training" \
+      io.k8s.display-name="ROCm 6.2 Python 3.11 PyTorch 2.4.1 base image for Training" \
+      io.k8s.description="ROCm 6.2 Python 3.11 PyTorch 2.4.1 image based on UBI9 for Training" \
       authoritative-source-url="https://github.com/opendatahub-io/distributed-workloads"
 
 # Copy license
@@ -25,8 +25,8 @@ RUN pip install --no-cache-dir --upgrade requests==2.32.3
 # Install ROCm
 WORKDIR /opt/app-root/bin
 
-ARG ROCM_VERSION=6.1.2
-ARG AMDGPU_VERSION=6.1.2
+ARG ROCM_VERSION=6.2.4
+ARG AMDGPU_VERSION=6.2.4
 
 RUN <<EOF
 cat <<EOD > /etc/yum.repos.d/rocm.repo
@@ -48,7 +48,7 @@ gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
 EOD
 EOF
 
-RUN dnf -y install rocm && dnf clean all && rm -rf /var/cache/dnf
+RUN dnf install -y rocm-developer-tools rocm-ml-sdk rocm-opencl-sdk rocm-openmp-sdk rocm-utils && dnf clean all && rm -rf /var/cache/dnf
 
 # Install Python packages
 

--- a/images/runtime/training/rocm/README.md
+++ b/images/runtime/training/rocm/README.md
@@ -5,5 +5,5 @@ ROCm enabled container image for Training in OpenShift AI.
 It includes the following layers:
 * UBI 9
 * Python 3.11
-* ROCm 6.1
+* ROCm 6.2
 * PyTorch 2.4.1


### PR DESCRIPTION
Closes [RHOAIENG-16892](https://issues.redhat.com/browse/RHOAIENG-16892)

## Description
Upgrade AMD Training operator runtime image to ROCm v6.2.4

## How Has This Been Tested?
Build the image locally and pushed to `https://quay.io/repository/shchugh/training?tab=tags&tag=kfto-rocm624` and then then successfully executed the KFTO tests with the new image

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
