### PR TITLE
Update timeout time for the TestTimeoutGpuProvisioning test

### DIFF
--- a/tests/kfto/kfto_training_test.go
+++ b/tests/kfto/kfto_training_test.go
@@ -108,7 +108,7 @@ func runKFTOPyTorchJob(t *testing.T, image string, gpu Accelerator, numGpus, num
 	}
 
 	// Make sure the PyTorch job succeeded
-	test.Eventually(PyTorchJob(test, namespace, tuningJob.Name), TestTimeoutDouble).Should(WithTransform(PyTorchJobConditionSucceeded, Equal(corev1.ConditionTrue)))
+	test.Eventually(PyTorchJob(test, namespace, tuningJob.Name), TestTimeoutGpuProvisioning).Should(WithTransform(PyTorchJobConditionSucceeded, Equal(corev1.ConditionTrue)))
 	test.T().Logf("PytorchJob %s/%s ran successfully", tuningJob.Namespace, tuningJob.Name)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The TestPyTorchJobSingleNodeSingleGpuWithCuda test is failing with timeout error which is the only test failing out of all Multi-node tests -
Compute resources used : 2* g4dn.xlarge

![image (194)](https://github.com/user-attachments/assets/a5de028b-d2ae-4312-beb7-95f44db5f97f)

![image (195)](https://github.com/user-attachments/assets/badba11d-04f1-470e-bc9a-a205afac87f5)

Test passed when updated the timeout time from 20 mins(TestTimeoutDouble) to 30mins(TestTimeoutGpuProvisioning)  here : :heavy_check_mark: 
https://github.com/opendatahub-io/distributed-workloads/blob/1445fa64c9643e78caaf76f653cebff7b1eb73eb/tests/kfto/kfto_training_test.go#L111

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
