### PR TITLE
e2e tests: Remove duplicate template parsing

### DIFF
--- a/tests/common/template.go
+++ b/tests/common/template.go
@@ -69,8 +69,6 @@ func ParseTemplate(t support.Test, inputTemplate []byte, props interface{}) []by
 	buffer := new(bytes.Buffer)
 	err = parsedTemplate.Execute(buffer, props)
 	t.Expect(err).NotTo(gomega.HaveOccurred())
-	err = parsedTemplate.Execute(buffer, props) // NOTE: not sure if template package handles recursive case
-	t.Expect(err).NotTo(gomega.HaveOccurred())
 
 	return buffer.Bytes()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The duplicate parsing produce doubled training script, causing training delays and text replacing issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by running `TestMnistRayCpu` on OCP.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
