### PR TITLE
Add VAP tests for PyTorchJobs

### DIFF
--- a/tests/odh/validating_admission_policy_test.go
+++ b/tests/odh/validating_admission_policy_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	kftrainingv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	. "github.com/onsi/gomega"
 	awv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
 	. "github.com/project-codeflare/codeflare-common/support"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	testingpytorchjob "sigs.k8s.io/kueue/pkg/util/testingjobs/pytorchjob"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 )
 
@@ -42,19 +44,22 @@ import (
 // The Validating Admission Policy feature gate is GA and enabled by default from OCP v4.17 (k8s v1.30)
 
 var (
-	ns           *corev1.Namespace
-	nsNoLabel    *corev1.Namespace
-	rf           *kueuev1beta1.ResourceFlavor
-	cq           *kueuev1beta1.ClusterQueue
-	lq           *kueuev1beta1.LocalQueue
-	rc           *rayv1.RayCluster
-	aw           *awv1beta2.AppWrapper
-	vapb         *vapv1.ValidatingAdmissionPolicyBinding
-	vapbCopy     *vapv1.ValidatingAdmissionPolicyBinding
-	awWithLQName = "aw-with-lq"
-	awNoLQName   = "aw-no-lq"
-	rcWithLQName = "rc-with-lq"
-	rcNoLQName   = "rc-no-lq"
+	ns            *corev1.Namespace
+	nsNoLabel     *corev1.Namespace
+	rf            *kueuev1beta1.ResourceFlavor
+	cq            *kueuev1beta1.ClusterQueue
+	lq            *kueuev1beta1.LocalQueue
+	rc            *rayv1.RayCluster
+	aw            *awv1beta2.AppWrapper
+	pyt           *kftrainingv1.PyTorchJob
+	vapb          *vapv1.ValidatingAdmissionPolicyBinding
+	vapbCopy      *vapv1.ValidatingAdmissionPolicyBinding
+	awWithLQName  = "aw-with-lq"
+	awNoLQName    = "aw-no-lq"
+	rcWithLQName  = "rc-with-lq"
+	rcNoLQName    = "rc-no-lq"
+	pytWithLQName = "pyt-with-lq"
+	pytNoLQName   = "pyt-no-lq"
 )
 
 const (
@@ -156,6 +161,18 @@ func TestValidatingAdmissionPolicy(t *testing.T) {
 				defer test.Client().Dynamic().Resource(awv1beta2.GroupVersion.WithResource("appwrappers")).Namespace(ns.Name).Delete(test.Ctx(), aw.Name, metav1.DeleteOptions{})
 			})
 		})
+		t.Run("PyTorchJob Tests", func(t *testing.T) {
+			t.Run("PyTorchJob should be admitted with the 'kueue.x-k8s.io/queue-name' label set", func(t *testing.T) {
+				err = createPyTorchJob(test, ns.Name, withLQ)
+				test.Expect(err).ToNot(HaveOccurred())
+				defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(ns.Name).Delete(test.Ctx(), pyt.Name, metav1.DeleteOptions{})
+			})
+			t.Run("PyTorchJob should not be admitted without the 'kueue.x-k8s.io/queue-name' label set", func(t *testing.T) {
+				err = createPyTorchJob(test, ns.Name, noLQ)
+				test.Expect(err).ToNot(BeNil())
+				defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(ns.Name).Delete(test.Ctx(), pyt.Name, metav1.DeleteOptions{})
+			})
+		})
 	})
 
 	/**************************************************************************
@@ -194,6 +211,18 @@ func TestValidatingAdmissionPolicy(t *testing.T) {
 				err = createAppWrapper(test, ns.Name, noLQ)
 				test.Expect(err).ToNot(HaveOccurred())
 				defer test.Client().Dynamic().Resource(awv1beta2.GroupVersion.WithResource("appwrappers")).Namespace(ns.Name).Delete(test.Ctx(), aw.Name, metav1.DeleteOptions{})
+			})
+		})
+		t.Run("PyTorchJob Tests", func(t *testing.T) {
+			t.Run("PyTorchJob should be admitted with the 'kueue.x-k8s.io/queue-name' label set", func(t *testing.T) {
+				err = createPyTorchJob(test, ns.Name, withLQ)
+				test.Expect(err).ToNot(HaveOccurred())
+				defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(ns.Name).Delete(test.Ctx(), pyt.Name, metav1.DeleteOptions{})
+			})
+			t.Run("PyTorchJob should be admitted without the 'kueue.x-k8s.io/queue-name' label set", func(t *testing.T) {
+				err = createPyTorchJob(test, ns.Name, noLQ)
+				test.Expect(err).ToNot(HaveOccurred())
+				defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(ns.Name).Delete(test.Ctx(), pyt.Name, metav1.DeleteOptions{})
 			})
 		})
 	})
@@ -271,6 +300,28 @@ func TestValidatingAdmissionPolicy(t *testing.T) {
 				defer test.Client().Dynamic().Resource(awv1beta2.GroupVersion.WithResource("appwrappers")).Namespace(nsNoLabel.Name).Delete(test.Ctx(), aw.Name, metav1.DeleteOptions{})
 			})
 		})
+		t.Run("PyTorchJob Tests", func(t *testing.T) {
+			t.Run("PyTorchJob should be admitted with the 'kueue.x-k8s.io/queue-name' label in a labeled namespace", func(t *testing.T) {
+				err = createPyTorchJob(test, ns.Name, withLQ)
+				test.Expect(err).ToNot(HaveOccurred())
+				defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(ns.Name).Delete(test.Ctx(), pyt.Name, metav1.DeleteOptions{})
+			})
+			t.Run("PyTorchJob should not be admitted without the 'kueue.x-k8s.io/queue-name' label in a labeled namespace", func(t *testing.T) {
+				err = createPyTorchJob(test, ns.Name, noLQ)
+				test.Expect(err).ToNot(BeNil())
+				defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(ns.Name).Delete(test.Ctx(), pyt.Name, metav1.DeleteOptions{})
+			})
+			t.Run("PyTorchJob should be admitted with the 'kueue.x-k8s.io/queue-name' label in any other namespace", func(t *testing.T) {
+				err = createPyTorchJob(test, nsNoLabel.Name, withLQ)
+				test.Expect(err).ToNot(HaveOccurred())
+				defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(ns.Name).Delete(test.Ctx(), pyt.Name, metav1.DeleteOptions{})
+			})
+			t.Run("PyTorchJob should be admitted without the 'kueue.x-k8s.io/queue-name' label in any other namespace", func(t *testing.T) {
+				err = createPyTorchJob(test, nsNoLabel.Name, noLQ)
+				test.Expect(err).ToNot(HaveOccurred())
+				defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(ns.Name).Delete(test.Ctx(), pyt.Name, metav1.DeleteOptions{})
+			})
+		})
 	})
 }
 
@@ -313,5 +364,15 @@ func createAppWrapper(test Test, namespaceName string, localQueue bool) error {
 	}
 	awMap, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(aw)
 	_, err := test.Client().Dynamic().Resource(awv1beta2.GroupVersion.WithResource("appwrappers")).Namespace(namespaceName).Create(test.Ctx(), &unstructured.Unstructured{Object: awMap}, metav1.CreateOptions{})
+	return err
+}
+
+func createPyTorchJob(test Test, namespaceName string, localQueue bool) error {
+	if localQueue {
+		pyt = testingpytorchjob.MakePyTorchJob(uniqueSuffix(pytWithLQName), namespaceName).Queue(lq.Name).Obj()
+	} else {
+		pyt = testingpytorchjob.MakePyTorchJob(uniqueSuffix(pytNoLQName), namespaceName).Obj()
+	}
+	_, err := test.Client().Kubeflow().KubeflowV1().PyTorchJobs(namespaceName).Create(test.Ctx(), pyt, metav1.CreateOptions{})
 	return err
 }

--- a/tests/odh/validating_admission_policy_test.go
+++ b/tests/odh/validating_admission_policy_test.go
@@ -228,27 +228,27 @@ func TestValidatingAdmissionPolicy(t *testing.T) {
 	})
 
 	/**************************************************************************
-	Testing the 2nd alternative behavior which targets specific namespaces that have the 'kueue-managed' label
+	Testing the 2nd alternative behavior which targets specific namespaces that have the 'kueue.openshift.io/managed' label
 	**************************************************************************/
 	t.Run("Custom ValidatingAdmissionPolicyBinding", func(t *testing.T) {
-		// Update the test namespace with the new 'kueue-managed' label
+		// Update the test namespace with the new 'kueue.openshift.io/managed' label
 		ns, err = test.Client().Core().CoreV1().Namespaces().Get(test.Ctx(), ns.Name, metav1.GetOptions{})
 		if ns.Labels == nil {
 			ns.Labels = map[string]string{}
 		}
-		ns.Labels["kueue-managed"] = "true"
+		ns.Labels["kueue.openshift.io/managed"] = "true"
 		_, err = test.Client().Core().CoreV1().Namespaces().Update(test.Ctx(), ns, metav1.UpdateOptions{})
 		test.Eventually(func() bool {
 			ns, _ = test.Client().Core().CoreV1().Namespaces().Get(test.Ctx(), ns.Name, metav1.GetOptions{})
-			return ns.Labels["kueue-managed"] == "true"
+			return ns.Labels["kueue.openshift.io/managed"] == "true"
 		}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(BeTrue())
 		test.Expect(err).ToNot(HaveOccurred())
 
-		// Apply the ValidatingAdmissionPolicyBinding targetting namespaces with the label 'kueue-managed'
+		// Apply the ValidatingAdmissionPolicyBinding targetting namespaces with the label 'kueue.openshift.io/managed'
 		vapb, err = test.Client().Core().AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(test.Ctx(), vapb.Name, metav1.GetOptions{})
 		test.Expect(err).ToNot(HaveOccurred())
 
-		vapb.Spec.MatchResources.NamespaceSelector.MatchLabels = map[string]string{"kueue-managed": "true"}
+		vapb.Spec.MatchResources.NamespaceSelector.MatchLabels = map[string]string{"kueue.openshift.io/managed": "true"}
 		_, err = test.Client().Core().AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Update(test.Ctx(), vapb, metav1.UpdateOptions{})
 		test.Expect(err).ToNot(HaveOccurred())
 		defer revertVAPB(test, vapbCopy)

--- a/tests/odh/validating_admission_policy_test.go
+++ b/tests/odh/validating_admission_policy_test.go
@@ -370,8 +370,12 @@ func createAppWrapper(test Test, namespaceName string, localQueue bool) error {
 func createPyTorchJob(test Test, namespaceName string, localQueue bool) error {
 	if localQueue {
 		pyt = testingpytorchjob.MakePyTorchJob(uniqueSuffix(pytWithLQName), namespaceName).Queue(lq.Name).Obj()
+		pyt.Spec.PyTorchReplicaSpecs[kftrainingv1.PyTorchJobReplicaTypeMaster].Template.Spec.Containers[0].Name = "pytorch"
+		pyt.Spec.PyTorchReplicaSpecs[kftrainingv1.PyTorchJobReplicaTypeWorker].Template.Spec.Containers[0].Name = "pytorch"
 	} else {
 		pyt = testingpytorchjob.MakePyTorchJob(uniqueSuffix(pytNoLQName), namespaceName).Obj()
+		pyt.Spec.PyTorchReplicaSpecs[kftrainingv1.PyTorchJobReplicaTypeMaster].Template.Spec.Containers[0].Name = "pytorch"
+		pyt.Spec.PyTorchReplicaSpecs[kftrainingv1.PyTorchJobReplicaTypeWorker].Template.Spec.Containers[0].Name = "pytorch"
 	}
 	_, err := test.Client().Kubeflow().KubeflowV1().PyTorchJobs(namespaceName).Create(test.Ctx(), pyt, metav1.CreateOptions{})
 	return err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Jira: https://issues.redhat.com/browse/RHOAIENG-19694 
ValidatingAdmissionPolicy PR: https://github.com/opendatahub-io/kueue/pull/76 

## Description
<!--- Describe your changes in detail -->
- Added VAP tests for `PyTorchJobs`.
- Added new AppWrapper test cases.
- Refactored the tests for readability and scalability.

## How Can This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This should be tested alongside this PR: https://github.com/opendatahub-io/kueue/pull/76 

1. Ensure OCP cluster is `>=v4.17`
2. Ensure Kueue, CodeFlare-Operator(and AppWrapper controller), KubeRay, and Training-Operator are installed.
3. Run `go test -timeout 1m ./tests/odh/validating_admission_policy_test.go ./tests/odh/support.go`.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
