### PR TITLE
Remove assertion if S3 bucket is missing and support PVC

### DIFF
--- a/examples/ray-finetune-llm-deepspeed/ray_finetune_llm_deepspeed.ipynb
+++ b/examples/ray-finetune-llm-deepspeed/ray_finetune_llm_deepspeed.ipynb
@@ -130,12 +130,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Storage configuration\n",
+    "storage_path = /opt/app-root/src\n",
+    "\n",
     "# The S3 bucket where to store checkpoint.\n",
     "# It can be set manually, otherwise it's retrieved from configured the data connection.\n",
     "s3_bucket = ''\n",
     "if not s3_bucket:\n",
     "    s3_bucket = os.environ.get('AWS_S3_BUCKET')\n",
-    "assert s3_bucket, \"An S3 bucket must be provided to store checkpoints\""
+    "if s3_bucket:\n",
+    "    storage_path = s3://{s3_bucket}"
    ]
   },
   {
@@ -147,6 +151,7 @@
    },
    "outputs": [],
    "source": [
+    "# Submit Ray job\n",
     "submission_id = client.submit_job(\n",
     "    entrypoint=\"python ray_finetune_llm_deepspeed.py \"\n",
     "               \"--model-name=meta-llama/Meta-Llama-3.1-8B \"\n",
@@ -154,7 +159,7 @@
     "               \"--num-devices=8 \"\n",
     "               \"--num-epochs=3 \"\n",
     "               \"--ds-config=./deepspeed_configs/zero_3_offload_optim_param.json \"\n",
-    "               f\"--storage-path=s3://{s3_bucket}/ray_finetune_llm_deepspeed/ \"\n",
+    "               f\"--storage-path={storage_path}/ray_finetune_llm_deepspeed/ \"\n",
     "               \"--batch-size-per-device=32 \"\n",
     "               \"--eval-batch-size-per-device=32 \",\n",
     "    runtime_env={\n",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove the assertion that checks if a S3 bucket is set as the example can be used with PVC as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
