### PR TITLE
Update KFTO-SDK MNIST test to use latest training image and the SDK v…

### DIFF
--- a/tests/kfto/kfto_mnist_sdk_test.go
+++ b/tests/kfto/kfto_mnist_sdk_test.go
@@ -19,6 +19,7 @@ package kfto
 import (
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	. "github.com/project-codeflare/codeflare-common/support"
@@ -41,10 +42,11 @@ func TestMnistSDK(t *testing.T) {
 	CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
 
 	requiredChangesInNotebook := map[string]string{
-		"${api_url}":   GetOpenShiftApiUrl(test),
-		"${password}":  userToken,
-		"${num_gpus}":  "0",
-		"${namespace}": namespace.Name,
+		"${api_url}":        GetOpenShiftApiUrl(test),
+		"${password}":       userToken,
+		"${num_gpus}":       "0",
+		"${namespace}":      namespace.Name,
+		"${training_image}": GetCudaTrainingImage(),
 	}
 
 	jupyterNotebook := string(readFile(test, "resources/mnist_kfto.ipynb"))
@@ -81,7 +83,7 @@ func TestMnistSDK(t *testing.T) {
 		Should(WithTransform(PyTorchJobConditionRunning, Equal(v1.ConditionTrue)))
 
 	// Make sure that the job eventually succeeds
-	test.Eventually(PyTorchJob(test, namespace.Name, "pytorch-ddp")).
+	test.Eventually(PyTorchJob(test, namespace.Name, "pytorch-ddp"), TestTimeoutLong, 1*time.Second).
 		Should(WithTransform(PyTorchJobConditionSucceeded, Equal(v1.ConditionTrue)))
 
 	// TODO: write torch job logs?

--- a/tests/kfto/resources/mnist_kfto.ipynb
+++ b/tests/kfto/resources/mnist_kfto.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "ebdb3af3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -U kubeflow-training"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 6,
    "id": "b55bc3ea-4ce3-49bf-bb1f-e209de8ca47a",
    "metadata": {
@@ -19,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "72dd1751",
    "metadata": {},
    "outputs": [],
@@ -28,7 +38,8 @@
     "num_gpus = \"${num_gpus}\"\n",
     "openshift_api_url = \"${api_url}\"\n",
     "namespace = \"${namespace}\"\n",
-    "token = \"${password}\""
+    "token = \"${password}\"\n",
+    "training_image= \"${training_image}\""
    ]
   },
   {
@@ -57,9 +68,9 @@
     "   train_func=train_func,\n",
     "   num_workers=1,\n",
     "   resources_per_worker={\"gpu\": num_gpus},\n",
-    "   base_image=\"quay.io/kpostlet/torch-train:with-minivision\",\n",
-    "   # packages_to_install=[\"torchvision==0.19.0\", \"--target=/tmp/lib\"],\n",
-    "   # env_vars={\"PYTHONPATH\": \"/tmp/lib:$PYTHONPATH\", \"NCCL_DEBUG\": \"INFO\", \"TORCH_DISTRIBUTED_DEBUG\": \"DETAIL\"}\n",
+    "   base_image=training_image,\n",
+    "   packages_to_install=[\"torchvision==0.19.0\",\"minio==7.2.13\", \"--target=/tmp/lib\"],\n",
+    "   env_vars={\"PYTHONPATH\": \"/tmp/lib:$PYTHONPATH\", \"NCCL_DEBUG\": \"INFO\", \"TORCH_DISTRIBUTED_DEBUG\": \"DETAIL\"}\n",
     ")"
    ]
   },


### PR DESCRIPTION
[RHOAIENG-19847](https://issues.redhat.com/browse/RHOAIENG-19847)

Update ODH MnistSdkTest to use latest training image and SDK version

latest notebook image used for testing : 
`NOTEBOOK_IMAGE=quay.io/modh/odh-generic-data-science-notebook@sha256:d0ba5fc23e2b3846763f60e8ade8a0f561cdcd2bf6717df6e732f6f8b68b89c4`

![image](https://github.com/user-attachments/assets/cfd9274a-cb15-480f-b14e-c32506855de8)
![image](https://github.com/user-attachments/assets/cb8a6a43-b9fb-46f3-9061-d20bd05cb3c8)

Notebook logs : https://privatebin.corp.redhat.com/?480de67d07d3c9dd#6tTsAsSfq3b7gy62UPLceYG31e43WKmPoJAvjarJG5hQ
Pytorch master pod logs : https://privatebin.corp.redhat.com/?83fe5bb64ca22a4f#4zw8ahqDkKmMtCZSmJ8CCC2e8zC9iHae13SQpMqsqNrU

ToDo : 
To test it with the notebook-image built with the latest training-sdk version included : https://github.com/opendatahub-io/notebooks/pull/921
To test with latest training-image which has fix for allowing to install any package on top of training-image : https://github.com/opendatahub-io/distributed-workloads/pull/324