### PR TITLE
Add Flash Attention to ROCm training image

### DIFF
--- a/images/runtime/training/rocm/Dockerfile
+++ b/images/runtime/training/rocm/Dockerfile
@@ -64,6 +64,19 @@ RUN micropipenv install && \
     chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
     fix-permissions /opt/app-root -P
 
+# Install Flash Attention
+ENV GPU_ARCHS=gfx90a;gfx941;gfx942
+
+RUN pip install wheel ninja
+
+RUN export TMP_DIR=$(mktemp -d) \
+    && cd $TMP_DIR \
+    && git clone --depth 1 --branch v2.7.4 https://github.com/Dao-AILab/flash-attention.git \
+    && cd flash-attention \
+    && git submodule update --init
+    && MAX_JOBS="16" python3 setup.py install --verbose \
+    && rm -rf $TMP_DIR
+
 # Restore user workspace
 USER 1001
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add Flash Attention 2 to ROCm training image.

## How Has This Been Tested?

Successfully built and pushed at quay.io/astefanu/training@sha256:0485504d352c14d9009c44872921e8a87092c28f43a0ae8aa126885f9db95700

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
