### PR TITLE
Adjust fms-hf-tuning tests to use granite-3b-code-base-2k model

### DIFF
--- a/tests/fms/environment.go
+++ b/tests/fms/environment.go
@@ -32,8 +32,14 @@ const (
 	huggingfaceTokenEnvVar = "HF_TOKEN"
 	// The environment variable specifying name of PersistenceVolumeClaim containing GPTQ models
 	gptqModelPvcNameEnvVar = "GPTQ_MODEL_PVC_NAME"
+	// The environment variable specifying s3 bucket name used to download files
+	storageBucketDownloadName = "AWS_STORAGE_BUCKET_DOWNLOAD"
+	// The environment variable specifying s3 bucket name used to upload files
+	storageBucketUploadName = "AWS_STORAGE_BUCKET_UPLOAD"
+	// The environment variable specifying s3 bucket folder path used to download model from
+	storageBucketDownloadModelPath = "AWS_STORAGE_BUCKET_DOWNLOAD_MODEL_PATH"
 	// The environment variable specifying s3 bucket folder path used to store model
-	storageBucketModelPath = "AWS_STORAGE_BUCKET_MODEL_PATH"
+	storageBucketUploadModelPath = "AWS_STORAGE_BUCKET_UPLOAD_MODEL_PATH"
 )
 
 func GetFmsHfTuningImage(t Test) string {
@@ -66,9 +72,24 @@ func GetGptqModelPvcName() (string, error) {
 	return image, nil
 }
 
-func GetStorageBucketModelPath() string {
-	storageBucketModelPath := lookupEnvOrDefault(storageBucketModelPath, "")
-	return storageBucketModelPath
+func GetStorageBucketDownloadModelPath() string {
+	storageBucketDownloadModelPath := lookupEnvOrDefault(storageBucketDownloadModelPath, "")
+	return storageBucketDownloadModelPath
+}
+
+func GetStorageBucketUploadModelPath() string {
+	storageBucketUploadModelPath := lookupEnvOrDefault(storageBucketUploadModelPath, "")
+	return storageBucketUploadModelPath
+}
+
+func GetStorageBucketDownloadName() (string, bool) {
+	storageBucketDownloadName, exists := os.LookupEnv(storageBucketDownloadName)
+	return storageBucketDownloadName, exists
+}
+
+func GetStorageBucketUploadName() (string, bool) {
+	storageBucketUploadName, exists := os.LookupEnv(storageBucketUploadName)
+	return storageBucketUploadName, exists
 }
 
 func lookupEnvOrDefault(key, value string) string {

--- a/tests/fms/kfto_kueue_sft_GPU_test.go
+++ b/tests/fms/kfto_kueue_sft_GPU_test.go
@@ -144,8 +144,8 @@ func runMultiGpuPytorchjob(t *testing.T, modelConfigFile string, numberOfGpus in
 	test.Eventually(PyTorchJob(test, namespace, tuningJob.Name), 60*time.Minute).Should(WithTransform(PyTorchJobConditionSucceeded, Equal(corev1.ConditionTrue)))
 	test.T().Logf("PytorchJob %s/%s ran successfully", tuningJob.Namespace, tuningJob.Name)
 
-	_, bucketEndpointSet := GetStorageBucketDefaultEndpoint()
-	if bucketEndpointSet {
+	_, bucketUploadSet := GetStorageBucketUploadName()
+	if bucketUploadSet {
 		uploadToS3(test, namespace, outputPvc.Name, "model")
 	}
 }

--- a/tests/fms/resources/config.json
+++ b/tests/fms/resources/config.json
@@ -1,6 +1,6 @@
 {
-    "model_name_or_path": "/tmp/model/bloom-560m",
-    "training_data_path": "/etc/config/twitter_complaints_small.json",
+    "model_name_or_path": "<MODEL_PATH_PLACEHOLDER>",
+    "training_data_path": "/tmp/dataset/alpaca_data.json",
     "output_dir": "/mnt/output/model",
     "save_model_dir": "/mnt/output/model",
     "num_train_epochs": 1.0,
@@ -12,7 +12,7 @@
     "weight_decay": 0.0,
     "lr_scheduler_type": "cosine",
     "include_tokens_per_second": true,
-    "response_template": "\n### Label:",
+    "response_template": "\n### Response:",
     "dataset_text_field": "output",
     "use_flash_attn": false
 }

--- a/tests/fms/resources/config_lora.json
+++ b/tests/fms/resources/config_lora.json
@@ -1,6 +1,6 @@
 {
-    "model_name_or_path": "/tmp/model/bloom-560m",
-    "training_data_path": "/etc/config/twitter_complaints_small.json",
+    "model_name_or_path": "<MODEL_PATH_PLACEHOLDER>",
+    "training_data_path": "/tmp/dataset/alpaca_data.json",
     "output_dir": "/mnt/output/model",
     "save_model_dir": "/mnt/output/model",
     "num_train_epochs": 1.0,
@@ -12,7 +12,7 @@
     "weight_decay": 0.0,
     "lr_scheduler_type": "cosine",
     "include_tokens_per_second": true,
-    "response_template": "\n### Label:",
+    "response_template": "\n### Response:",
     "dataset_text_field": "output",
     "use_flash_attn": false,
     "peft_method": "lora",

--- a/tests/fms/resources/config_qlora.json
+++ b/tests/fms/resources/config_qlora.json
@@ -1,6 +1,6 @@
 {
     "model_name_or_path": "TechxGenus/Meta-Llama-3-8B-GPTQ",
-    "training_data_path": "/etc/config/twitter_complaints_small.json",
+    "training_data_path": "/tmp/dataset/alpaca_data.json",
     "output_dir": "/mnt/output/model",
     "save_model_dir": "/mnt/output/model",
     "num_train_epochs": 1.0,
@@ -12,7 +12,7 @@
     "weight_decay": 0.0,
     "lr_scheduler_type": "cosine",
     "include_tokens_per_second": true,
-    "response_template": "\n### Label:",
+    "response_template": "\n### Response:",
     "dataset_text_field": "output",
     "use_flash_attn": true,
     "peft_method": "lora",

--- a/tests/fms/support.go
+++ b/tests/fms/support.go
@@ -48,7 +48,7 @@ func uploadToS3(test Test, namespace string, pvcName string, storedAssetsPath st
 	test.Expect(found).To(BeTrue(), "Storage bucket secret key needs to be specified for S3 upload")
 	bucketName, found := GetStorageBucketName()
 	test.Expect(found).To(BeTrue(), "Storage bucket name needs to be specified for S3 upload")
-	bucketPath := GetStorageBucketModelPath()
+	bucketPath := GetStorageBucketUploadModelPath()
 
 	// Create Secret with AWS/Minio access credentials
 	secretData := map[string]string{
@@ -115,4 +115,82 @@ func uploadToS3(test Test, namespace string, pvcName string, storedAssetsPath st
 		),
 	)
 	test.Expect(GetJob(test, namespace, job.Name)).To(WithTransform(JobConditionCompleted, Equal(corev1.ConditionTrue)), "Job uploading content to S3 bucket failed")
+}
+
+func downloadFromS3(test Test, namespace string, pvcName string, storedAssetsPath string) {
+	defaultEndpoint, found := GetStorageBucketDefaultEndpoint()
+	test.Expect(found).To(BeTrue(), "Storage bucket default endpoint needs to be specified for download from S3")
+	accessKeyId, found := GetStorageBucketAccessKeyId()
+	test.Expect(found).To(BeTrue(), "Storage bucket access key id needs to be specified for download from S3")
+	secretKey, found := GetStorageBucketSecretKey()
+	test.Expect(found).To(BeTrue(), "Storage bucket secret key needs to be specified for download from S3")
+	bucketName, found := GetStorageBucketName()
+	test.Expect(found).To(BeTrue(), "Storage bucket name needs to be specified for download from S3")
+	bucketPath := GetStorageBucketDownloadModelPath()
+
+	// Create Secret with AWS/Minio access credentials
+	secretData := map[string]string{
+		"S3ENDPOINT":  defaultEndpoint,
+		"ACCESSKEYID": accessKeyId,
+		"SECRETKEY":   secretKey,
+	}
+	secret := CreateSecret(test, namespace, secretData)
+	defer test.Client().Core().CoreV1().Secrets(namespace).Delete(test.Ctx(), secret.Name, metav1.DeleteOptions{})
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "download-",
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: Ptr(int32(0)),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:    "s3",
+							Image:   GetMinioCliImage(),
+							Command: []string{"/bin/sh", "-c"},
+							Args:    []string{fmt.Sprintf("mc alias set mys3 $S3ENDPOINT $ACCESSKEYID $SECRETKEY; mc cp --recursive mys3/%s/%s /mnt/%s", bucketName, bucketPath, storedAssetsPath)},
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									SecretRef: &corev1.SecretEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{Name: secret.Name},
+									},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "mounted-volume",
+									MountPath: "/mnt",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "mounted-volume",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: pvcName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	job, err := test.Client().Core().BatchV1().Jobs(namespace).Create(test.Ctx(), job, metav1.CreateOptions{})
+	test.Expect(err).NotTo(HaveOccurred())
+	test.T().Logf("Created Job %s/%s successfully", job.Namespace, job.Name)
+	defer test.Client().Core().BatchV1().Jobs(namespace).Delete(test.Ctx(), job.Name, metav1.DeleteOptions{PropagationPolicy: Ptr(metav1.DeletePropagationBackground)})
+
+	test.Eventually(Job(test, namespace, job.Name), 60*time.Minute).Should(
+		Or(
+			WithTransform(JobConditionCompleted, Equal(corev1.ConditionTrue)),
+			WithTransform(JobConditionFailed, Equal(corev1.ConditionTrue)),
+		),
+	)
+	test.Expect(GetJob(test, namespace, job.Name)).To(WithTransform(JobConditionCompleted, Equal(corev1.ConditionTrue)), "Job downloading content from S3 bucket failed")
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
From fms-hf-tuning 2.6.0 the training script isn't able to process existing bloom model.
So this PR upgrades fms tests to use granite-3b-code-base-2k model.

Another upgrade is to use GPU for training, which should speed up test execution time.
For disconnected environment the granite model can be downloaded from S3 bucket.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
