### PR TITLE
Install BitsAndBytes from source in ROCm training image

### DIFF
--- a/images/runtime/training/rocm/Dockerfile
+++ b/images/runtime/training/rocm/Dockerfile
@@ -48,7 +48,7 @@ gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
 EOD
 EOF
 
-RUN dnf install -y rocm-developer-tools rocm-ml-sdk rocm-opencl-sdk rocm-openmp-sdk rocm-utils && dnf clean all && rm -rf /var/cache/dnf
+RUN dnf install -y cmake rocm-developer-tools rocm-ml-sdk rocm-opencl-sdk rocm-openmp-sdk rocm-utils && dnf clean all && rm -rf /var/cache/dnf
 
 # Install Python packages
 
@@ -76,6 +76,21 @@ RUN export TMP_DIR=$(mktemp -d) \
     && git submodule update --init \
     && MAX_JOBS="16" python3 setup.py install --verbose \
     && rm -rf $TMP_DIR
+
+# Install BitsAndBytes
+RUN export TMP_DIR=$(mktemp -d) \
+    && cd $TMP_DIR \
+    && git clone --depth 1 --branch rocm_enabled_multi_backend https://github.com/ROCm/bitsandbytes.git \
+    && cd bitsandbytes \
+    && cmake -S . \
+    && make \
+    && cmake -DCOMPUTE_BACKEND=hip -DBNB_ROCM_ARCH=$GPU_ARCHS -S . \
+    && make \
+    && cp bitsandbytes/libbitsandbytes_rocm62.so bitsandbytes/libbitsandbytes_rocm61.so \
+    && pip install --no-deps . \
+    && rm -rf $TMP_DIR
+# Install a compatible version of pytorch-triton-rocm
+RUN pip install --force-reinstall pytorch-triton-rocm==3.1.0 --index-url https://download.pytorch.org/whl/nightly/rocm6.2
 
 # Restore user workspace
 USER 1001

--- a/images/runtime/training/rocm/Pipfile
+++ b/images/runtime/training/rocm/Pipfile
@@ -9,7 +9,6 @@ verify_ssl = true
 name = "pytorch"
 
 [packages]
-bitsandbytes = ">=0.45.3"
 peft = ">=0.14.0"
 datasets = ">=2.15.0"
 liger-kernel = "==0.5.4"

--- a/images/runtime/training/rocm/Pipfile.lock
+++ b/images/runtime/training/rocm/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a5abe112bc05177b7dde70737cfa6897e431b28a071b621187bcf242553adf6f"
+            "sha256": "ead10a8dd924e99e3eb18f4baa3fa3ab770b752a03205e4077e934264f737cd6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -174,15 +174,6 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==25.1.0"
-        },
-        "bitsandbytes": {
-            "hashes": [
-                "sha256:720d67ffa8a5c61c958fb62517e8abbb2ab0ac1b33b66506ae911cb34c836c70",
-                "sha256:7251d71814a653b2b78b69149f1e88753598688c760c99cbbfb0512ba4ea39c6"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==0.45.3"
         },
         "certifi": {
             "hashes": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the installation of the bitsandbytes package on ROCm.

## How Has This Been Tested?

Successfully tested with the LLM SFT Trainer example on 8x AMD Instinct MI300X:

![image](https://github.com/user-attachments/assets/945de666-a872-4817-a8cb-833a5e688ff8)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
