### PR TITLE
Allow insecure communication to upload/download from S3-compatible st…

### DIFF
--- a/tests/fms/support.go
+++ b/tests/fms/support.go
@@ -73,7 +73,7 @@ func uploadToS3(test Test, namespace string, pvcName string, storedAssetsPath st
 							Name:    "s3",
 							Image:   GetMinioCliImage(),
 							Command: []string{"/bin/sh", "-c"},
-							Args:    []string{fmt.Sprintf("mc alias set mys3 $S3ENDPOINT $ACCESSKEYID $SECRETKEY; mc cp --recursive /mnt/%s mys3/%s/%s", storedAssetsPath, bucketName, bucketPath)},
+							Args:    []string{fmt.Sprintf("mc alias set --insecure mys3 $S3ENDPOINT $ACCESSKEYID $SECRETKEY; mc cp --recursive --insecure /mnt/%s mys3/%s/%s", storedAssetsPath, bucketName, bucketPath)},
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									SecretRef: &corev1.SecretEnvSource{
@@ -151,7 +151,7 @@ func downloadFromS3(test Test, namespace string, pvcName string, storedAssetsPat
 							Name:    "s3",
 							Image:   GetMinioCliImage(),
 							Command: []string{"/bin/sh", "-c"},
-							Args:    []string{fmt.Sprintf("mc alias set mys3 $S3ENDPOINT $ACCESSKEYID $SECRETKEY; mc cp --recursive mys3/%s/%s /mnt/%s", bucketName, bucketPath, storedAssetsPath)},
+							Args:    []string{fmt.Sprintf("mc alias set --insecure mys3 $S3ENDPOINT $ACCESSKEYID $SECRETKEY; mc cp --recursive --insecure mys3/%s/%s /mnt/%s", bucketName, bucketPath, storedAssetsPath)},
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									SecretRef: &corev1.SecretEnvSource{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
It seems the SFTTrainer tests failed In disconnected due to the `upload/download_from_s3 jobs` are failing due to minio client's default tls-verification : https://github.com/opendatahub-io/distributed-workloads/blob/main/tests/fms/support.go.. 
So need to adjust the command accordingly to skip TLS by using `--insecure` flag

```
mc: <ERROR> Unable to initialize new alias from the provided credentials. Get "https://bastion.ods-dis-aws-03.aws.rh-ods.com:9000/probe-bsign-ffpdq4k5sqpnkapbhyh3x92dzi1szh/?location=": tls: failed to verify certificate: x509: certificate signed by unknown authority.
mc: <ERROR> Unable to prepare URL for copying. Unable to guess the type of copy operation.
```
```
support.go:195: 
20:57:19          Job downloading content from S3 bucket failed
```

Ran same tests by adding `--insecure` flag, and tests passed !

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
