### PR TITLE
Update test-notebook resource to re-adjust kubeflow-training SDK's py…

### DIFF
--- a/tests/kfto/resources/mnist_kfto.ipynb
+++ b/tests/kfto/resources/mnist_kfto.ipynb
@@ -2,16 +2,6 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ebdb3af3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install -U kubeflow-training"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 6,
    "id": "b55bc3ea-4ce3-49bf-bb1f-e209de8ca47a",
    "metadata": {
@@ -69,8 +59,8 @@
     "   num_workers=1,\n",
     "   resources_per_worker={\"gpu\": num_gpus},\n",
     "   base_image=training_image,\n",
-    "   packages_to_install=[\"torchvision==0.19.0\",\"minio==7.2.13\", \"--target=/tmp/lib\"],\n",
-    "   env_vars={\"PYTHONPATH\": \"/tmp/lib:$PYTHONPATH\", \"NCCL_DEBUG\": \"INFO\", \"TORCH_DISTRIBUTED_DEBUG\": \"DETAIL\"}\n",
+    "   packages_to_install=[\"torchvision==0.19.0\",\"minio==7.2.13\"],\n",
+    "   env_vars={\"NCCL_DEBUG\": \"INFO\", \"TORCH_DISTRIBUTED_DEBUG\": \"DETAIL\"}\n",
     ")"
    ]
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
[RHOAIENG-19847](https://issues.redhat.com/browse/RHOAIENG-19847)
Related PR : https://github.com/opendatahub-io/distributed-workloads/pull/335

Update kubeflow-training-sdk-test-notebook resource :
- to re-adjust kubeflow-training SDK's pytorchjob creation input params as the workaround for installing packages on top of training-image is not needed anymore 
- to skip upgrading SDK version explicitly as using a notebook image having `kubeflow-training==v1.9.0` pre-installed 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Images used : 
```
TrainingCudaImage: quay.io/modh/training:py311-cuda121-torch241
LatestNotebookImage : quay.io/opendatahub/workbench-images:jupyter-datascience-ubi9-python-3.11-20250305
```
![Screenshot 2025-03-06 at 2 18 27 PM](https://github.com/user-attachments/assets/82d63e0e-913b-47ba-86c7-0a7990555e71)
Logs : https://privatebin.corp.redhat.com/?91abc29b62c12039#H1UBHHS2j1eDVHjGwxLJwDCXGtacq18xEZvoV4fRGxfu

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
