### PR TITLE
Use processing_class instead of deprecated tokenizer argument in SFTTrainer

### DIFF
--- a/examples/kfto-sft-llm/sft.ipynb
+++ b/examples/kfto-sft-llm/sft.ipynb
@@ -265,7 +265,7 @@
     "        train_dataset=train_dataset,\n",
     "        eval_dataset=test_dataset,\n",
     "        peft_config=get_peft_config(model_args),\n",
-    "        tokenizer=tokenizer,\n",
+    "        processing_class=tokenizer,\n",
     "    )\n",
     "\n",
     "    if trainer.accelerator.is_main_process and hasattr(trainer.model, \"print_trainable_parameters\"):\n",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use processing_class instead of deprecated tokenizer argument in SFTTrainer

## How Has This Been Tested?

Successfully ran the LLM fine-tuning example.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
