### PR TITLE
Fix broken OpenShift permissisons for training CUDA image

### DIFF
--- a/images/runtime/training/cuda/Dockerfile
+++ b/images/runtime/training/cuda/Dockerfile
@@ -84,7 +84,8 @@ RUN pip install wheel
 RUN pip install --no-cache-dir flash-attn==2.7.4.post1 --no-build-isolation
 
 # Upgrade NCCL to a more recent version until we upgrade torch
-RUN pip install nvidia-nccl-cu12==2.26.2
+RUN pip install nvidia-nccl-cu12==2.26.2 && \
+    fix-permissions /opt/app-root -P
 
 # Restore user workspace
 USER 1001


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Run `fix-permissions` after installing `nvidia-nccl-cu12`.
It seems that `nvidia-nccl-cu12` mess with permissions, preventing package installations using PyTorchJob SDK.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
