### PR TITLE
Removing installation of kubeflow-training as it has been updated in …

### DIFF
--- a/examples/kfto-dreambooth/dreambooth.ipynb
+++ b/examples/kfto-dreambooth/dreambooth.ipynb
@@ -9,24 +9,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "d17aee83-941a-4b87-bf7d-3ff8632761de",
-   "metadata": {},
-   "source": [
-    "Remove once kubeflow-training SDK is upgraded to 1.9.0"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5e9f7764-94ed-4c71-bb57-9b57a3e8f556",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install -qqU kubeflow-training"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "13b89c3c-a969-46fb-8314-b57f47061f4b",

--- a/examples/kfto-sft-llm/sft.ipynb
+++ b/examples/kfto-sft-llm/sft.ipynb
@@ -21,17 +21,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a55002d2-a230-4fa9-b542-fa475d8ddfb2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install the Kubeflow SDK (this can be removed once the latest version is included into workbench images)\n",
-    "!pip install git+https://github.com/kubeflow/trainer.git@release-1.9#subdirectory=sdk/python"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "29aed0af-9136-4f2f-9f6d-45413cb9b0a8",
    "metadata": {},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
[RHOAIENG-22304 
](https://issues.redhat.com/browse/RHOAIENG-22304)
## Description
<!--- Describe your changes in detail -->
Removing kubeflow sdk installation from examples as it is no longer needed as it has been added to the notebook images in this [PR](https://github.com/opendatahub-io/notebooks/pull/1002).
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
