### PR TITLE
Egg-based install is not supported anymore according to PEP-517

### DIFF
--- a/images/runtime/training/py311-rocm62-torch251/Dockerfile
+++ b/images/runtime/training/py311-rocm62-torch251/Dockerfile
@@ -74,7 +74,7 @@ RUN export TMP_DIR=$(mktemp -d) \
     && git clone --depth 1 --branch v2.7.4 https://github.com/Dao-AILab/flash-attention.git \
     && cd flash-attention \
     && git submodule update --init \
-    && MAX_JOBS="16" python3 setup.py install --verbose \
+    && MAX_JOBS="16" pip install --no-build-isolation . \
     && rm -rf $TMP_DIR
 
 # Install BitsAndBytes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the installation of Flash Attention 2 from source for the KFTO ROCm training image to comply with PEP-517.

## How Has This Been Tested?

I've successfully run the LLM fine-tuning with KFTO example with AMD accelerators using the pre-built `quay.io/astefanu/training:py311-rocm62-torch251-2` image.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
