### PR TITLE
Add workflow to build and push test images

### DIFF
--- a/.github/workflows/build-and-push-test-images.yml
+++ b/.github/workflows/build-and-push-test-images.yml
@@ -1,0 +1,33 @@
+# This workflow build and push test images to https://quay.io/repository/opendatahub/distributed-workloads-tests
+
+name: Build and Push test images
+on:
+  push:
+      branches:
+        - 'main'
+      paths:
+        - 'go.mod'
+        - 'go.sum'
+        - 'tests/**'
+  workflow_dispatch:
+
+jobs:
+  build-and-push-test-images:
+    runs-on:  ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Login to Quay.io
+      id: podman-login-quay
+      run:  podman login --username ${{ secrets.QUAY_ODH_DW_TESTS_USERNAME }} --password ${{ secrets.QUAY_ODH_DW_TESTS_TOKEN }} quay.io
+
+    - name: Build test image
+      run:  make build-test-image
+
+    - name: Push test image
+      run:  make push-test-image
+
+    - name: Logout from Quay.io
+      if: always() && steps.podman-login-quay.outcome == 'success'
+      run:  podman logout quay.io

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,7 @@ verify-imports: openshift-goimports ## Run import verifications.
 .PHONY: build-test-image
 build-test-image:
 	podman build -f images/tests/Dockerfile -t ${E2E_TEST_IMAGE} .
+
+.PHONY: push-test-image
+push-test-image:
+	podman push ${E2E_TEST_IMAGE}


### PR DESCRIPTION
Closes [RHOAIENG-18526](https://issues.redhat.com/browse/RHOAIENG-18526)

## Description
Add workflow to build and push test images to https://quay.io/repository/opendatahub/distributed-workloads-tests

## How Has This Been Tested?
Build and push the image via workflow in my [fork](https://github.com/ChughShilpa/distributed-workloads/actions/runs/15114366726)
can see latest image [here](https://quay.io/repository/shchugh/opendatahub/distributed-workloads-tests?tab=tags&tag=latest)

## Merge criteria:

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
