### PR TITLE
Reapply site-packages permissions after installing pytorch-triton-rocm in ROCm dockerfiles

### DIFF
--- a/images/runtime/training/py311-rocm62-torch241/Dockerfile
+++ b/images/runtime/training/py311-rocm62-torch241/Dockerfile
@@ -89,8 +89,13 @@ RUN export TMP_DIR=$(mktemp -d) \
     && cp bitsandbytes/libbitsandbytes_rocm62.so bitsandbytes/libbitsandbytes_rocm61.so \
     && pip install --no-deps . \
     && rm -rf $TMP_DIR
+    
 # Install a compatible version of pytorch-triton-rocm
 RUN pip install --force-reinstall pytorch-triton-rocm==3.1.0 --index-url https://download.pytorch.org/whl/nightly/rocm6.2
+
+# Reapply write permissions on site‑packages
+RUN chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
+    fix-permissions /opt/app-root -P
 
 # Restore user workspace
 USER 1001

--- a/images/runtime/training/py311-rocm62-torch251/Dockerfile
+++ b/images/runtime/training/py311-rocm62-torch251/Dockerfile
@@ -88,8 +88,13 @@ RUN export TMP_DIR=$(mktemp -d) \
     && make \
     && pip install --no-deps . \
     && rm -rf $TMP_DIR
+    
 # Install a compatible version of pytorch-triton-rocm
 RUN pip install --force-reinstall pytorch-triton-rocm==3.1.0 --index-url https://download.pytorch.org/whl/nightly/rocm6.2
+
+# Reapply write permissions on site‑packages
+RUN chmod -R g+w /opt/app-root/lib/python3.11/site-packages && \
+    fix-permissions /opt/app-root -P
 
 # Restore user workspace
 USER 1001


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
while trying to use latest kubeflow-training sdk version 1.9.2 to create pytorchjob after passing packages-to-install argument, below issue came up : 
```
ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: 'libproton.so'
Check the permissions.
Traceback (most recent call last):
File "/tmp/tmp.R13JmiiOrT/ephemeral_script.py", line 147, in <module>
train_func()
File "/tmp/tmp.R13JmiiOrT/ephemeral_script.py", line 6, in train_func
from torchvision import datasets, transforms
ModuleNotFoundError: No module named 'torchvision
```

Re‑chmod and fix-permissions on /opt/app-root/lib/python3.11/site-packages in
a new layer so that newly installed shared libraries (e.g. libproton.so) are
writable by the non‑root container user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
