### PR TITLE
Update: Correct label for local queue

### DIFF
--- a/tests/kfto/kfto_training_test.go
+++ b/tests/kfto/kfto_training_test.go
@@ -219,7 +219,7 @@ func createKFTOPyTorchJob(test Test, namespace string, config corev1.ConfigMap, 
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "kfto-llm-",
 			Labels: map[string]string{
-				"kueue.x-k8s.io/default-queue": localQueue.Name,
+				"kueue.x-k8s.io/queue-name": localQueue.Name,
 			},
 		},
 		Spec: kftov1.PyTorchJobSpec{


### PR DESCRIPTION
Use correct label for local queue

## Description


## How Has This Been Tested?
Tested locally by runnning kfto tests

## Merge criteria:


- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
