### PR TITLE
Removing faiss requirement in feast rag example

### DIFF
--- a/examples/kfto_feast_rag/rag_feast.ipynb
+++ b/examples/kfto_feast_rag/rag_feast.ipynb
@@ -20,9 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Note: `faiss-cpu` is included here due to an assumption in the Hugging Face `RagRetriever` class\n",
-    "# that the FAISS library is required, even though it's not directly used in this example.\n",
-    "%pip install --quiet feast[milvus] sentence-transformers datasets faiss-cpu\n",
+    "%pip install --quiet feast[milvus] sentence-transformers datasets\n",
     "%pip install bigtree==0.19.2\n",
     "%pip install marshmallow==3.10.0 "
    ]
@@ -145,7 +143,7 @@
     "print(df[\"embedding\"].apply(lambda x: len(x) if isinstance(x, list) else str(type(x))).value_counts())  # Check lengths\n",
     "\n",
     "# Save to Parquet\n",
-    "df.to_parquet(\"wiki_dpr.parquet\", index=False)\n",
+    "df.to_parquet(\"feature_repo/data/wiki_dpr.parquet\", index=False)\n",
     "print(\"Saved to wiki_dpr.parquet\")"
    ]
   },
@@ -232,7 +230,7 @@
     "import sys\n",
     "sys.path.append(\"..\")\n",
     "from feast_rag_retriever import FeastVectorStore, FeastRAGRetriever, FeastIndex\n",
-    "from rag_project_repo import wiki_passage_feature_view\n",
+    "from ragproject_repo import wiki_passage_feature_view\n",
     "\n",
     "generator_config=generator_model.config\n",
     "question_encoder = AutoModel.from_pretrained(\"sentence-transformers/all-MiniLM-L6-v2\")\n",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the requirement for the faiss library in the feast rag example following on from this [PR](https://github.com/huggingface/transformers/pull/38624).
I have also fixed a couple of path/import issues and updating the notebook name to remove kfto as it is not used in the notebook.

This PR should not be merged until after the next HF Transformers release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by running the notebook on the team cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
