### PR TITLE
Get storageclass dynamically which supports RWX provisioning 

### DIFF
--- a/tests/common/support/client.go
+++ b/tests/common/support/client.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	storageclient "k8s.io/client-go/kubernetes/typed/storage/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -43,6 +44,7 @@ type Client interface {
 	Image() imagev1.Interface
 	Ray() rayclient.Interface
 	Dynamic() dynamic.Interface
+	Storage() storageclient.StorageV1Interface
 }
 
 type testClient struct {
@@ -54,6 +56,7 @@ type testClient struct {
 	image    imagev1.Interface
 	ray      rayclient.Interface
 	dynamic  dynamic.Interface
+	storage  storageclient.StorageV1Interface
 }
 
 var _ Client = (*testClient)(nil)
@@ -88,6 +91,10 @@ func (t *testClient) Ray() rayclient.Interface {
 
 func (t *testClient) Dynamic() dynamic.Interface {
 	return t.dynamic
+}
+
+func (t *testClient) Storage() storageclient.StorageV1Interface {
+	return t.storage
 }
 
 func newTestClient(cfg *rest.Config) (Client, *rest.Config, error) {
@@ -142,6 +149,11 @@ func newTestClient(cfg *rest.Config) (Client, *rest.Config, error) {
 		return nil, nil, err
 	}
 
+	storageClient, err := storageclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return &testClient{
 		core:     kubeClient,
 		kubeflow: kubeflowClient,
@@ -151,5 +163,6 @@ func newTestClient(cfg *rest.Config) (Client, *rest.Config, error) {
 		image:    imageClient,
 		ray:      rayClient,
 		dynamic:  dynamicClient,
+		storage:  storageClient,
 	}, cfg, nil
 }

--- a/tests/common/support/storage.go
+++ b/tests/common/support/storage.go
@@ -1,0 +1,36 @@
+package support
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var rwxSupportedProvisioners = map[string]bool{
+	"nfs.csi.k8s.io": true,
+}
+
+func GetStorageClasses(t Test) []storagev1.StorageClass {
+	t.T().Helper()
+	scList, err := t.Client().Storage().StorageClasses().List(t.Ctx(), metav1.ListOptions{})
+	t.Expect(err).NotTo(gomega.HaveOccurred())
+	return scList.Items
+}
+
+func GetRWXStorageClass(t Test) (*storagev1.StorageClass, error) {
+	t.T().Helper()
+
+	storageClasses := GetStorageClasses(t)
+
+	for _, sc := range storageClasses {
+		if rwxSupportedProvisioners[sc.Provisioner] {
+			t.T().Logf("Found StorageClass '%s' with provisioner '%s' which is likely to support RWX.", sc.Name, sc.Provisioner)
+			return &sc, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no StorageClass found that is known to support ReadWriteMany (RWX) access mode")
+}

--- a/tests/fms/kfto_kueue_sft_GPU_test.go
+++ b/tests/fms/kfto_kueue_sft_GPU_test.go
@@ -115,7 +115,7 @@ func runMultiGpuPytorchjob(t *testing.T, modelConfigFile string, numberOfGpus in
 	defer test.Client().Core().CoreV1().ConfigMaps(namespace).Delete(test.Ctx(), config.Name, *metav1.NewDeleteOptions(0))
 
 	// Create PVC for trained model
-	outputPvc := CreatePersistentVolumeClaim(test, namespace, "200Gi", corev1.ReadWriteOnce)
+	outputPvc := CreatePersistentVolumeClaim(test, namespace, "200Gi", AccessModes(corev1.ReadWriteOnce))
 	defer test.Client().Core().CoreV1().PersistentVolumeClaims(namespace).Delete(test.Ctx(), outputPvc.Name, metav1.DeleteOptions{})
 
 	// Create training PyTorch job

--- a/tests/fms/kfto_kueue_sft_test.go
+++ b/tests/fms/kfto_kueue_sft_test.go
@@ -87,11 +87,11 @@ func runPytorchjobWithSFTtrainer(t *testing.T, modelConfigFile string) {
 	defer test.Client().Kueue().KueueV1beta1().LocalQueues(namespace).Delete(test.Ctx(), localQueue.Name, metav1.DeleteOptions{})
 
 	// Create PVC for base model
-	baseModelPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", corev1.ReadWriteOnce)
+	baseModelPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", AccessModes(corev1.ReadWriteOnce))
 	defer test.Client().Core().CoreV1().PersistentVolumeClaims(namespace).Delete(test.Ctx(), baseModelPvc.Name, metav1.DeleteOptions{})
 
 	// Create PVC for trained model
-	outputPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", corev1.ReadWriteOnce)
+	outputPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", AccessModes(corev1.ReadWriteOnce))
 	defer test.Client().Core().CoreV1().PersistentVolumeClaims(namespace).Delete(test.Ctx(), outputPvc.Name, metav1.DeleteOptions{})
 
 	// Load training job config file
@@ -183,7 +183,7 @@ func TestPytorchjobUsingKueueQuota(t *testing.T) {
 	localQueue := CreateKueueLocalQueue(test, namespace, clusterQueue.Name, AsDefaultQueue)
 
 	// Create PVC for base model
-	baseModelPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", corev1.ReadWriteOnce)
+	baseModelPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", AccessModes(corev1.ReadWriteOnce))
 	defer test.Client().Core().CoreV1().PersistentVolumeClaims(namespace).Delete(test.Ctx(), baseModelPvc.Name, metav1.DeleteOptions{})
 
 	// Load training job config file
@@ -208,7 +208,7 @@ func TestPytorchjobUsingKueueQuota(t *testing.T) {
 	config := CreateConfigMap(test, namespace, configData)
 
 	// Create first PVC for trained model
-	outputPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", corev1.ReadWriteOnce)
+	outputPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", AccessModes(corev1.ReadWriteOnce))
 	defer test.Client().Core().CoreV1().PersistentVolumeClaims(namespace).Delete(test.Ctx(), outputPvc.Name, metav1.DeleteOptions{})
 
 	// Create first training PyTorch job
@@ -219,7 +219,7 @@ func TestPytorchjobUsingKueueQuota(t *testing.T) {
 		Should(WithTransform(PyTorchJobConditionRunning, Equal(corev1.ConditionTrue)))
 
 	// Create second PVC for trained model
-	secondOutputPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", corev1.ReadWriteOnce)
+	secondOutputPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", AccessModes(corev1.ReadWriteOnce))
 	defer test.Client().Core().CoreV1().PersistentVolumeClaims(namespace).Delete(test.Ctx(), outputPvc.Name, metav1.DeleteOptions{})
 
 	// Create second training PyTorch job

--- a/tests/kfto/kfto_mnist_sdk_test.go
+++ b/tests/kfto/kfto_mnist_sdk_test.go
@@ -111,7 +111,7 @@ func runMnistSDK(t *testing.T, trainingImage string) {
 			jupyterNotebookConfigMapFileName, namespace.Name, GetOpenShiftApiUrl(test), userToken, 0, trainingImage)}
 
 	// Create PVC for Notebook
-	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", corev1.ReadWriteOnce)
+	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", AccessModes(corev1.ReadWriteOnce))
 
 	// Create Notebook CR
 	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, 0, notebookPVC)

--- a/tests/kfto/kfto_sft_llm_test.go
+++ b/tests/kfto/kfto_sft_llm_test.go
@@ -59,8 +59,12 @@ func kftoSftLlm(t *testing.T, modelName string) {
 	// Create role binding with Namespace specific admin cluster role
 	CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
 
+	// Get storageclass that supports RWX PVC provisioning
+	storageClass, err := GetRWXStorageClass(test)
+	test.Expect(err).ToNot(HaveOccurred(), "Failed to find an RWX supporting StorageClass")
+
 	// Create PVC for Notebook
-	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "500Gi", corev1.ReadWriteMany)
+	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "500Gi", AccessModes(corev1.ReadWriteMany), StorageClassName(storageClass.Name))
 
 	// Read and update the notebook content
 	notebookContent := odh.ReadFileExt(test, workingDirectory+"/../../examples/kfto-sft-llm/sft.ipynb")

--- a/tests/kfto/kfto_training_test.go
+++ b/tests/kfto/kfto_training_test.go
@@ -173,7 +173,7 @@ func runKFTOPyTorchJob(t *testing.T, image string, gpu Accelerator, numGpus, num
 	config := CreateConfigMap(test, namespace, configData)
 
 	// Create PVC for trained model
-	outputPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", corev1.ReadWriteOnce)
+	outputPvc := CreatePersistentVolumeClaim(test, namespace, "10Gi", AccessModes(corev1.ReadWriteOnce))
 	defer test.Client().Core().CoreV1().PersistentVolumeClaims(namespace).Delete(test.Ctx(), outputPvc.Name, metav1.DeleteOptions{})
 
 	// Create training PyTorch job

--- a/tests/odh/mnist_ray_test.go
+++ b/tests/odh/mnist_ray_test.go
@@ -127,7 +127,7 @@ func mnistRay(t *testing.T, numGpus int, gpuResourceName string, rayImage string
 	CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
 
 	// Create PVC for Notebook
-	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", corev1.ReadWriteOnce)
+	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", AccessModes(corev1.ReadWriteOnce))
 
 	notebookCommand := getNotebookCommand(rayImage)
 	// Create Notebook CR

--- a/tests/odh/mnist_raytune_hpo_test.go
+++ b/tests/odh/mnist_raytune_hpo_test.go
@@ -111,7 +111,7 @@ func mnistRayTuneHpo(t *testing.T, numGpus int) {
 	notebookCommand := getNotebookCommand(rayImage)
 
 	// Create PVC for Notebook
-	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", corev1.ReadWriteOnce)
+	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", AccessModes(corev1.ReadWriteOnce))
 
 	// Create Notebook CR
 	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, numGpus, notebookPVC)

--- a/tests/odh/ray_finetune_llm_deepspeed_test.go
+++ b/tests/odh/ray_finetune_llm_deepspeed_test.go
@@ -110,7 +110,7 @@ func rayFinetuneLlmDeepspeed(t *testing.T, numGpus int, modelName string, modelC
 	notebookCommand := getNotebookCommand(rayImage)
 
 	// Create PVC for Notebook
-	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", corev1.ReadWriteOnce)
+	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", AccessModes(corev1.ReadWriteOnce))
 
 	// Create Notebook CR
 	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, numGpus, notebookPVC)

--- a/tests/odh/raytune_oai_mr_grpc_test.go
+++ b/tests/odh/raytune_oai_mr_grpc_test.go
@@ -120,7 +120,7 @@ func raytuneHpo(t *testing.T, numGpus int) {
 	notebookCommand := getNotebookCommand(rayImage)
 
 	// Create PVC for Notebook
-	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", corev1.ReadWriteOnce)
+	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", AccessModes(corev1.ReadWriteOnce))
 
 	// Create Notebook CR
 	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, numGpus, notebookPVC)


### PR DESCRIPTION
This PR adds provision to dynamically get storageclass which supports RWX provisioning and use it for creating PVC. 

## Description
This PR 
- add support for `storage client` in client.go 
- add `GetStorageClasses` and `GetRWXStorageClass` method 
- modify `CreatePersistentVolumeClaim` method to use options pattern for two arguments namely `AccessModes` and `StorageClassName`

## How Has This Been Tested?
Testes this change manually by running tests
`go test -v -timeout 30m ./tests/kfto -run TestKftoSftLlmLlama3_1_8BInstruct`


## Merge criteria:


- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added utilities to retrieve storage classes and find storage classes that support ReadWriteMany (RWX) volumes.
- **Refactor**
  - Updated PersistentVolumeClaim creation to use helper functions for specifying access modes and storage class names, improving flexibility and consistency across tests.
- **Bug Fixes**
  - Ensured that storage classes supporting RWX are explicitly selected when required, enhancing compatibility for tests needing shared volumes.
- **Chores**
  - Extended test client to support Kubernetes StorageV1 API for unified storage-related interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->