### PR TITLE
Assert VAP PyTorchJob creation in gomega evaluation part

### DIFF
--- a/tests/kfto/validating_admission_policy_test.go
+++ b/tests/kfto/validating_admission_policy_test.go
@@ -212,11 +212,13 @@ func TestValidatingAdmissionPolicy(t *testing.T) {
 			})
 			t.Run("PyTorchJob should not be admitted without the 'kueue.x-k8s.io/queue-name' label in a labeled namespace", func(t *testing.T) {
 				test.Eventually(func() error {
-					err = createPyTorchJob(test, ns.Name)
-					test.Expect(err).To(HaveOccurred())
-					test.Expect(err.Error()).To(ContainSubstring("The label 'kueue.x-k8s.io/queue-name' is either missing or does not have a value set"))
-					return err
-				}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(HaveOccurred())
+					return createPyTorchJob(test, ns.Name)
+				}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(
+					And(
+						HaveOccurred(),
+						MatchError(ContainSubstring("The label 'kueue.x-k8s.io/queue-name' is either missing or does not have a value set")),
+					),
+				)
 				defer test.Client().Kubeflow().KubeflowV1().PyTorchJobs(ns.Name).Delete(test.Ctx(), pyt.Name, metav1.DeleteOptions{})
 			})
 			t.Run("PyTorchJob should be admitted with the 'kueue.x-k8s.io/queue-name' label in any other namespace", func(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Asserting error in test function phase skips repeated invocations, causing the test to fail if error doesn't assert on first try.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running the VAP test on OCP.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved the structure and readability of a test case that verifies rejection of a PyTorchJob missing a required label, making assertions more concise and expressive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->