### PR TITLE
Add provision for different container size for notebook creation & Add kftoSftLlm test for AMD Gpus

### DIFF
--- a/tests/common/notebook.go
+++ b/tests/common/notebook.go
@@ -47,6 +47,35 @@ func readFile(t Test, fileName string) []byte {
 	return file
 }
 
+var (
+	SmallContainerResources = ContainerResources{
+		Limits:   ResourceConfig{CPU: "2", Memory: "3Gi"},
+		Requests: ResourceConfig{CPU: "1", Memory: "3Gi"},
+	}
+	MediumContainerResources = ContainerResources{
+		Limits:   ResourceConfig{CPU: "6", Memory: "24Gi"},
+		Requests: ResourceConfig{CPU: "3", Memory: "24Gi"},
+	}
+)
+
+type ResourceConfig struct {
+	CPU              string
+	Memory           string
+	GPUResourceLabel string // e.g., "nvidia.com/gpu", "amd.com/gpu", or ""
+}
+
+type ContainerResources struct {
+	Limits   ResourceConfig
+	Requests ResourceConfig
+}
+
+type ContainerSize string
+
+const (
+	ContainerSizeSmall  ContainerSize = "small"
+	ContainerSizeMedium ContainerSize = "medium"
+)
+
 var notebookResource = schema.GroupVersionResource{Group: "kubeflow.org", Version: "v1", Resource: "notebooks"}
 
 type NotebookProps struct {
@@ -68,9 +97,11 @@ type NotebookProps struct {
 	S3SecretAccessKey         string
 	S3Endpoint                string
 	S3DefaultRegion           string
+	NotebookResources         ContainerResources
+	SizeSelection             ContainerSize
 }
 
-func CreateNotebook(test Test, namespace *corev1.Namespace, notebookUserToken string, command []string, jupyterNotebookConfigMapName, jupyterNotebookConfigMapFileName string, numGpus int, notebookPVC *corev1.PersistentVolumeClaim) {
+func CreateNotebook(test Test, namespace *corev1.Namespace, notebookUserToken string, command []string, jupyterNotebookConfigMapName, jupyterNotebookConfigMapFileName string, numGpus int, notebookPVC *corev1.PersistentVolumeClaim, containerSize ContainerSize, acceleratorResourceLabel ...string) {
 	s3BucketName, s3BucketNameExists := GetStorageBucketName()
 	s3AccessKeyId, _ := GetStorageBucketAccessKeyId()
 	s3SecretAccessKey, _ := GetStorageBucketSecretKey()
@@ -84,6 +115,36 @@ func CreateNotebook(test Test, namespace *corev1.Namespace, notebookUserToken st
 		s3SecretAccessKey = "''"
 		s3Endpoint = "''"
 		s3DefaultRegion = "''"
+	}
+
+	var selectedContainerResources ContainerResources
+	var gpuResourceLabel string
+	if len(acceleratorResourceLabel) == 1 {
+		gpuResourceLabel = acceleratorResourceLabel[0]
+	} else {
+		gpuResourceLabel = ""
+	}
+
+	if containerSize == ContainerSizeSmall {
+		selectedContainerResources = SmallContainerResources
+		// For small, ensure no GPU resource is requested
+		selectedContainerResources.Limits.GPUResourceLabel = ""
+		selectedContainerResources.Requests.GPUResourceLabel = ""
+	} else if containerSize == ContainerSizeMedium {
+		selectedContainerResources = MediumContainerResources
+
+		if gpuResourceLabel != "" && gpuResourceLabel != NVIDIA.ResourceLabel && gpuResourceLabel != AMD.ResourceLabel {
+			test.T().Errorf("Unsupported GPU resource label for medium size: %s. Must be '%s', '%s', or an empty string.", gpuResourceLabel, NVIDIA.ResourceLabel, AMD.ResourceLabel)
+			gpuResourceLabel = "" // Fallback to no GPU if label is invalid
+		}
+
+		// Apply the determined GPUResourceLabel
+		selectedContainerResources.Limits.GPUResourceLabel = gpuResourceLabel
+		selectedContainerResources.Requests.GPUResourceLabel = gpuResourceLabel
+	} else {
+		test.T().Errorf("Unsupported container size: %s. Must be '%s' or '%s'. Hence using '%s' container size.",
+			containerSize, ContainerSizeSmall, ContainerSizeMedium, ContainerSizeSmall)
+		selectedContainerResources = SmallContainerResources // Fallback to Small container size
 	}
 
 	// Read the Notebook CR from resources and perform replacements for custom values using go template
@@ -106,6 +167,8 @@ func CreateNotebook(test Test, namespace *corev1.Namespace, notebookUserToken st
 		S3DefaultRegion:           s3DefaultRegion,
 		PipIndexUrl:               GetPipIndexURL(),
 		PipTrustedHost:            GetPipTrustedHost(),
+		NotebookResources:         selectedContainerResources,
+		SizeSelection:             containerSize,
 	}
 	notebookTemplate, err := files.ReadFile("resources/custom-nb-small.yaml")
 	test.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/common/resources/custom-nb-small.yaml
+++ b/tests/common/resources/custom-nb-small.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     notebooks.opendatahub.io/inject-oauth: "true"
     notebooks.opendatahub.io/last-image-selection: codeflare-notebook:latest
-    notebooks.opendatahub.io/last-size-selection: Small
+    notebooks.opendatahub.io/last-size-selection: {{.SizeSelection}}
     notebooks.opendatahub.io/oauth-logout-url: https://odh-dashboard-{{.OpenDataHubNamespace}}.{{.IngressDomain}}/notebookController/kube-3aadmin/home
     opendatahub.io/link: https://jupyter-nb-kube-3aadmin-{{.Namespace}}.{{.IngressDomain}}/notebook/{{.Namespace}}/jupyter-nb-kube-3aadmin
     opendatahub.io/username: kube:admin
@@ -75,11 +75,17 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: "2"
-            memory: 3Gi
+            cpu: "{{ .NotebookResources.Limits.CPU }}"
+            memory: "{{ .NotebookResources.Limits.Memory }}"
+            {{ if .NotebookResources.Limits.GPUResourceLabel }} # Check if GPUResourceLabel is NOT empty
+            {{ .NotebookResources.Limits.GPUResourceLabel }}: 1
+            {{ end }}
           requests:
-            cpu: "1"
-            memory: 3Gi
+            cpu: "{{ .NotebookResources.Requests.CPU }}"
+            memory: "{{ .NotebookResources.Requests.Memory }}"
+            {{ if .NotebookResources.Requests.GPUResourceLabel }} # Check if GPUResourceLabel is NOT empty
+            {{ .NotebookResources.Requests.GPUResourceLabel }}: 1
+            {{ end }}
         volumeMounts:
         - mountPath: /opt/app-root/src
           name: jupyterhub-nb-kube-3aadmin-pvc

--- a/tests/kfto/kfto_mnist_sdk_test.go
+++ b/tests/kfto/kfto_mnist_sdk_test.go
@@ -114,7 +114,7 @@ func runMnistSDK(t *testing.T, trainingImage string) {
 	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", AccessModes(corev1.ReadWriteOnce))
 
 	// Create Notebook CR
-	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, 0, notebookPVC)
+	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, 0, notebookPVC, ContainerSizeSmall)
 
 	// Gracefully cleanup Notebook
 	defer func() {

--- a/tests/odh/mnist_ray_test.go
+++ b/tests/odh/mnist_ray_test.go
@@ -131,7 +131,7 @@ func mnistRay(t *testing.T, numGpus int, gpuResourceName string, rayImage string
 
 	notebookCommand := getNotebookCommand(rayImage)
 	// Create Notebook CR
-	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, numGpus, notebookPVC)
+	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, numGpus, notebookPVC, ContainerSizeSmall)
 
 	// Gracefully cleanup Notebook
 	defer func() {

--- a/tests/odh/mnist_raytune_hpo_test.go
+++ b/tests/odh/mnist_raytune_hpo_test.go
@@ -114,7 +114,7 @@ func mnistRayTuneHpo(t *testing.T, numGpus int) {
 	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", AccessModes(corev1.ReadWriteOnce))
 
 	// Create Notebook CR
-	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, numGpus, notebookPVC)
+	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, numGpus, notebookPVC, ContainerSizeSmall)
 
 	// Gracefully cleanup Notebook
 	defer func() {

--- a/tests/odh/ray_finetune_llm_deepspeed_test.go
+++ b/tests/odh/ray_finetune_llm_deepspeed_test.go
@@ -113,7 +113,7 @@ func rayFinetuneLlmDeepspeed(t *testing.T, numGpus int, modelName string, modelC
 	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", AccessModes(corev1.ReadWriteOnce))
 
 	// Create Notebook CR
-	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, numGpus, notebookPVC)
+	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, numGpus, notebookPVC, ContainerSizeSmall)
 
 	// Gracefully cleanup Notebook
 	defer func() {

--- a/tests/odh/raytune_oai_mr_grpc_test.go
+++ b/tests/odh/raytune_oai_mr_grpc_test.go
@@ -123,7 +123,7 @@ func raytuneHpo(t *testing.T, numGpus int) {
 	notebookPVC := CreatePersistentVolumeClaim(test, namespace.Name, "10Gi", AccessModes(corev1.ReadWriteOnce))
 
 	// Create Notebook CR
-	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, numGpus, notebookPVC)
+	CreateNotebook(test, namespace, userToken, notebookCommand, config.Name, jupyterNotebookConfigMapFileName, numGpus, notebookPVC, ContainerSizeSmall)
 
 	// Gracefully cleanup Notebook
 	defer func() {


### PR DESCRIPTION
Add provision for different container size for notebook creation & Add kftoSftLlm test for AMD Gpus


## Description
This PR 
- adds provision for selecting different container size for notebook creation 
- Extend test coverage for `kftoSftLlm` test to work with AMD gpus


## How Has This Been Tested?
Tested manually by running
```
export NOTEBOOK_USER_NAME=
export NOTEBOOK_USER_TOKEN=
export ODH_NAMESPACE=redhat-ods-applications
export TEST_OUTPUT_DIR=
export NOTEBOOK_IMAGE=export NOTEBOOK_IMAGE=quay.io/modh/odh-workbench-jupyter-pytorch-rocm-py311-ubi9@sha256:e86cf3bc7703c16f72b4fbeb398042570ba90a7415393e662bc9a39c6c197864
export HF_TOKEN=
```
`go test -timeout 30m -v ./tests/kfto -run TestKftoSftLlmLlama3_1_8BInstructWithROCmPyTorch251`

## Merge criteria:

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting notebook resource profiles, including CPU, memory, and optional GPU settings, when creating notebooks.
  - Introduced dynamic resource configuration in notebook templates, allowing flexible assignment of CPU, memory, and GPU resources.
  - Expanded test coverage to include GPU accelerator options (NVIDIA CUDA and AMD ROCm) for large language model fine-tuning workflows.

- **Bug Fixes**
  - Improved error messages for notebook execution failures, providing clearer diagnostics.

- **Tests**
  - Updated test cases to utilize the new resource profile selection feature when creating notebooks.
  - Added new tests for large language model fine-tuning with different GPU accelerators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->