### PR TITLE
update notebooks with cluster.apply()

### DIFF
--- a/examples/hpo-raytune/notebook/raytune-oai-MR-gRPC-demo.ipynb
+++ b/examples/hpo-raytune/notebook/raytune-oai-MR-gRPC-demo.ipynb
@@ -69,7 +69,7 @@
    "outputs": [],
    "source": [
     "# Bring up the cluster\n",
-    "cluster.up()\n",
+    "cluster.apply()\n",
     "cluster.wait_ready()"
    ]
   },

--- a/examples/hpo-raytune/notebook/raytune-oai-demo-mlmd.ipynb
+++ b/examples/hpo-raytune/notebook/raytune-oai-demo-mlmd.ipynb
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "# Bring up the cluster\n",
-    "cluster.up()\n",
+    "cluster.apply()\n",
     "cluster.wait_ready()"
    ]
   },

--- a/examples/hpo-raytune/notebook/raytune-oai-demo.ipynb
+++ b/examples/hpo-raytune/notebook/raytune-oai-demo.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "# Bring up the cluster\n",
-    "cluster.up()\n",
+    "cluster.apply()\n",
     "cluster.wait_ready()"
    ]
   },

--- a/examples/ray-finetune-llm-deepspeed/ray_finetune_llm_deepspeed.ipynb
+++ b/examples/ray-finetune-llm-deepspeed/ray_finetune_llm_deepspeed.ipynb
@@ -89,7 +89,7 @@
    "outputs": [],
    "source": [
     "# Create the Ray cluster\n",
-    "cluster.up()"
+    "cluster.apply()"
    ]
   },
   {

--- a/examples/stable-diffusion-dreambooth/notebook/00 Intro.ipynb
+++ b/examples/stable-diffusion-dreambooth/notebook/00 Intro.ipynb
@@ -67,7 +67,7 @@
    },
    "outputs": [],
    "source": [
-    "cluster.up()\n",
+    "cluster.apply()\n",
     "cluster.wait_ready()"
    ]
   },


### PR DESCRIPTION
## Issue link
[Jira link](https://issues.redhat.com/browse/RHOAIENG-26589)

## Description
Changed `cluster.up()` to `cluster.apply()` in  Notebooks

## How Has This Been Tested?
Run 'cluster.apply()' successfully on Jupyter Notebooks

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the cluster initialization method in several example notebooks to use a new approach for starting or configuring clusters. This change affects the cluster startup process but does not alter any other notebook logic or outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->