### PR TITLE
Update notebook image to 2.24 tag

### DIFF
--- a/images/tests/.env-odh
+++ b/images/tests/.env-odh
@@ -1,2 +1,2 @@
 FMS_HF_TUNING_IMAGE=quay.io/modh/fms-hf-tuning:release
-NOTEBOOK_IMAGE=quay.io/modh/odh-workbench-jupyter-datascience-cpu-py311-ubi9:rhoai-2.22
+NOTEBOOK_IMAGE=quay.io/modh/odh-workbench-jupyter-datascience-cpu-py311-ubi9:rhoai-2.24


### PR DESCRIPTION
Update notebook image to 2.24 tag for tests image

## Description
Update notebook image to 2.24 tag for tests image

## How Has This Been Tested?
No testing is required

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default notebook image version used in testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->