### PR TITLE
Remove Sanity tag from VAP tests

### DIFF
--- a/tests/kfto/validating_admission_policy_test.go
+++ b/tests/kfto/validating_admission_policy_test.go
@@ -56,8 +56,6 @@ var (
 func TestValidatingAdmissionPolicy(t *testing.T) {
 	test := With(t)
 
-	Tags(t, Sanity)
-
 	// Create namespace with unique name and required labels
 	var AsDefaultQueueNamespace = ErrorOption[*corev1.Namespace](func(ns *corev1.Namespace) error {
 		if ns.Labels == nil {


### PR DESCRIPTION
Remove Sanity tag from VAP tests

## Description
In latest RHOAI 2.23 release, VAP and VAPB is no longer supported for kueue and now the Kueue label `kueue.x-k8s.io/queue-name` validation is handled by Kueue-validating-webhook. So removing sanity tag to avoid failure in test execution

## How Has This Been Tested?
No need to test

## Merge criteria:

- [ \X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed the "Sanity" tag from the admission policy validation test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->