### PR TITLE
task(RHOAIENG-33492): Bump Ray runtime image to CUDA 12.8

### DIFF
--- a/.tekton/ray-cuda-push.yaml
+++ b/.tekton/ray-cuda-push.yaml
@@ -24,9 +24,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/modh/ray:2.47.1-py312-cu121
+    value: quay.io/modh/ray:2.47.1-py312-cu128
   - name: additional-tag
-    value: 2.47.1-py312-cu121-{{revision}}
+    value: 2.47.1-py312-cu128-{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 * `MINIO_CLI_IMAGE` (Optional) - Minio CLI image used for uploading/downloading data from/into s3 bucket
 * `TEST_TIER` (Optional) - Specifies test tier to run, skipping tests which don't belong to specified test tier. Supported test tiers: Smoke, Sanity, Tier1, Tier2, Tier3, Pre-Upgrade and Post-Upgrade. Test tier can also be provided using test parameter `testTier`.
 
-    NOTE: `quay.io/modh/ray:2.35.0-py311-cu121` is the default image used for creating a RayCluster resource. If you have your own custom ray image which suits your purposes, specify it in `TEST_RAY_IMAGE` environment variable.
+    NOTE: `quay.io/modh/ray:2.47.1-py312-cu128` is the default image used for creating a RayCluster resource. If you have your own custom ray image which suits your purposes, specify it in `TEST_RAY_IMAGE` environment variable.
 
 ### Environment variables for fms-hf-tuning test suite
 

--- a/images/runtime/ray/cuda/Dockerfile
+++ b/images/runtime/ray/cuda/Dockerfile
@@ -3,34 +3,43 @@ ARG IMAGE_TAG=9.6-1755735361
 
 FROM registry.access.redhat.com/ubi9/python-${PYTHON_VERSION}:${IMAGE_TAG}
 
-LABEL name="ray-ubi9-py312-cu121" \
-      summary="CUDA 12.1 Python 3.12 image based on UBI9 for Ray" \
-      description="CUDA 12.1 Python 3.12 image based on UBI9 for Ray" \
-      io.k8s.display-name="CUDA 12.1 Python 3.12 base image for Ray" \
-      io.k8s.description="CUDA 12.1 Python 3.12 image based on UBI9 for Ray" \
+ARG TARGETARCH
+
+LABEL name="ray-ubi9-py312-cu128" \
+      summary="CUDA 12.8 Python 3.12 image based on UBI9 for Ray" \
+      description="CUDA 12.8 Python 3.12 image based on UBI9 for Ray" \
+      io.k8s.display-name="CUDA 12.8 Python 3.12 base image for Ray" \
+      io.k8s.description="CUDA 12.8 Python 3.12 image based on UBI9 for Ray" \
       authoritative-source-url="https://github.com/opendatahub-io/distributed-workloads"
 
 # Install CUDA base from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/base/Dockerfile
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.8.0/ubi9/base/Dockerfile
 USER 0
 WORKDIR /opt/app-root/bin
 
-ENV NVARCH=x86_64
-ENV NVIDIA_REQUIRE_CUDA="cuda>=12.1 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=525,driver<526 brand=unknown,driver>=525,driver<526 brand=nvidia,driver>=525,driver<526 brand=nvidiartx,driver>=525,driver<526 brand=geforce,driver>=525,driver<526 brand=geforcertx,driver>=525,driver<526 brand=quadro,driver>=525,driver<526 brand=quadrortx,driver>=525,driver<526 brand=titan,driver>=525,driver<526 brand=titanrtx,driver>=525,driver<526"
-ENV NV_CUDA_CUDART_VERSION=12.1.105-1
-
-COPY cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
+ENV NVIDIA_REQUIRE_CUDA="cuda>=12.8 brand=unknown,driver>=470,driver<471 brand=grid,driver>=470,driver<471 brand=tesla,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=vapps,driver>=470,driver<471 brand=vpc,driver>=470,driver<471 brand=vcs,driver>=470,driver<471 brand=vws,driver>=470,driver<471 brand=cloudgaming,driver>=470,driver<471 brand=unknown,driver>=535,driver<536 brand=grid,driver>=535,driver<536 brand=tesla,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=vapps,driver>=535,driver<536 brand=vpc,driver>=535,driver<536 brand=vcs,driver>=535,driver<536 brand=vws,driver>=535,driver<536 brand=cloudgaming,driver>=535,driver<536 brand=unknown,driver>=550,driver<551 brand=grid,driver>=550,driver<551 brand=tesla,driver>=550,driver<551 brand=nvidia,driver>=550,driver<551 brand=quadro,driver>=550,driver<551 brand=quadrortx,driver>=550,driver<551 brand=nvidiartx,driver>=550,driver<551 brand=vapps,driver>=550,driver<551 brand=vpc,driver>=550,driver<551 brand=vcs,driver>=550,driver<551 brand=vws,driver>=550,driver<551 brand=cloudgaming,driver>=550,driver<551 brand=unknown,driver>=560,driver<561 brand=grid,driver>=560,driver<561 brand=tesla,driver>=560,driver<561 brand=nvidia,driver>=560,driver<561 brand=quadro,driver>=560,driver<561 brand=quadrortx,driver>=560,driver<561 brand=nvidiartx,driver>=560,driver<561 brand=vapps,driver>=560,driver<561 brand=vpc,driver>=560,driver<561 brand=vcs,driver>=560,driver<561 brand=vws,driver>=560,driver<561 brand=cloudgaming,driver>=560,driver<561 brand=unknown,driver>=565,driver<566 brand=grid,driver>=565,driver<566 brand=tesla,driver>=565,driver<566 brand=nvidia,driver>=565,driver<566 brand=quadro,driver>=565,driver<566 brand=quadrortx,driver>=565,driver<566 brand=nvidiartx,driver>=565,driver<566 brand=vapps,driver>=565,driver<566 brand=vpc,driver>=565,driver<566 brand=vcs,driver>=565,driver<566 brand=vws,driver>=565,driver<566 brand=cloudgaming,driver>=565,driver<566"
+ENV NV_CUDA_CUDART_VERSION=12.8.57-1
 
 RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
+    if [ "${TARGETARCH}" = "arm64" ]; then NVARCH=sbsa; else NVARCH=x86_64; fi && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
-ENV CUDA_VERSION=12.1.1
+ENV CUDA_VERSION=12.8.0
+
+COPY cuda.repo-* ./
+COPY NGC-DL-CONTAINER-LICENSE /
+
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+        cp cuda.repo-arm64 /etc/yum.repos.d/cuda.repo; \
+    else \
+        cp cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo; \
+    fi
 
 # For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
 RUN yum upgrade -y && yum install -y \
-    cuda-cudart-12-1-${NV_CUDA_CUDART_VERSION} \
-    cuda-compat-12-1 \
+    cuda-cudart-12-8-${NV_CUDA_CUDART_VERSION} \
+    cuda-compat-12-8 \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
@@ -41,30 +50,28 @@ RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
-COPY NGC-DL-CONTAINER-LICENSE /
-
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
 # Install CUDA runtime from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/runtime/Dockerfile
-ENV NV_CUDA_LIB_VERSION=12.1.1-1
-ENV NV_NVTX_VERSION=12.1.105-1
-ENV NV_LIBNPP_VERSION=12.1.0.40-1
-ENV NV_LIBNPP_PACKAGE=libnpp-12-1-${NV_LIBNPP_VERSION}
-ENV NV_LIBCUBLAS_VERSION=12.1.3.1-1
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.8.0/ubi9/runtime/Dockerfile
+ENV NV_CUDA_LIB_VERSION=12.8.0-1
+ENV NV_NVTX_VERSION=12.8.55-1
+ENV NV_LIBNPP_VERSION=12.3.3.65-1
+ENV NV_LIBNPP_PACKAGE=libnpp-12-8-${NV_LIBNPP_VERSION}
+ENV NV_LIBCUBLAS_VERSION=12.8.3.14-1
 ENV NV_LIBNCCL_PACKAGE_NAME=libnccl
-ENV NV_LIBNCCL_PACKAGE_VERSION=2.17.1-1
-ENV NV_LIBNCCL_VERSION=2.17.1
-ENV NCCL_VERSION=2.17.1
-ENV NV_LIBNCCL_PACKAGE=${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda12.1
+ENV NV_LIBNCCL_PACKAGE_VERSION=2.25.1-1
+ENV NV_LIBNCCL_VERSION=2.25.1
+ENV NCCL_VERSION=2.25.1
+ENV NV_LIBNCCL_PACKAGE=${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda12.8
 
 RUN yum install -y \
-    cuda-libraries-12-1-${NV_CUDA_LIB_VERSION} \
-    cuda-nvtx-12-1-${NV_NVTX_VERSION} \
+    cuda-libraries-12-8-${NV_CUDA_LIB_VERSION} \
+    cuda-nvtx-12-8-${NV_NVTX_VERSION} \
     ${NV_LIBNPP_PACKAGE} \
-    libcublas-12-1-${NV_LIBCUBLAS_VERSION} \
+    libcublas-12-8-${NV_LIBCUBLAS_VERSION} \
     ${NV_LIBNCCL_PACKAGE} \
     && yum clean all \
     && rm -rf /var/cache/yum/*
@@ -73,45 +80,48 @@ RUN yum install -y \
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 
 # Install CUDA devel from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/devel/Dockerfile
-ENV NV_CUDA_LIB_VERSION=12.1.1-1
-ENV NV_NVPROF_VERSION=12.1.105-1
-ENV NV_NVPROF_DEV_PACKAGE=cuda-nvprof-12-1-${NV_NVPROF_VERSION}
-ENV NV_CUDA_CUDART_DEV_VERSION=12.1.105-1
-ENV NV_NVML_DEV_VERSION=12.1.105-1
-ENV NV_LIBCUBLAS_DEV_VERSION=12.1.3.1-1
-ENV NV_LIBNPP_DEV_VERSION=12.1.0.40-1
-ENV NV_LIBNPP_DEV_PACKAGE=libnpp-devel-12-1-${NV_LIBNPP_DEV_VERSION}
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.8.0/ubi9/devel/Dockerfile
+ENV NV_CUDA_LIB_VERSION=12.8.0-1
+# ARM64 doesn't have nvprof package - set in runtime
+ENV NV_NVPROF_VERSION=12.8.57-1
+ENV NV_NVPROF_DEV_PACKAGE=cuda-nvprof-12-8-${NV_NVPROF_VERSION}
+ENV NV_CUDA_CUDART_DEV_VERSION=12.8.57-1
+ENV NV_NVML_DEV_VERSION=12.8.55-1
+ENV NV_LIBCUBLAS_DEV_VERSION=12.8.3.14-1
+ENV NV_LIBNPP_DEV_VERSION=12.3.3.65-1
+ENV NV_LIBNPP_DEV_PACKAGE=libnpp-devel-12-8-${NV_LIBNPP_DEV_VERSION}
 ENV NV_LIBNCCL_DEV_PACKAGE_NAME=libnccl-devel
-ENV NV_LIBNCCL_DEV_PACKAGE_VERSION=2.17.1-1
-ENV NCCL_VERSION=2.17.1
-ENV NV_LIBNCCL_DEV_PACKAGE=${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.1
-ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.1.1-1
-ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-1-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
+ENV NV_LIBNCCL_DEV_PACKAGE_VERSION=2.25.1-1
+ENV NCCL_VERSION=2.25.1
+ENV NV_LIBNCCL_DEV_PACKAGE=${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda12.8
+ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.8.0-1
+ENV NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE=cuda-nsight-compute-12-8-${NV_CUDA_NSIGHT_COMPUTE_VERSION}
 
 RUN yum install -y \
     make \
     findutils \
-    cuda-command-line-tools-12-1-${NV_CUDA_LIB_VERSION} \
-    cuda-libraries-devel-12-1-${NV_CUDA_LIB_VERSION} \
-    cuda-minimal-build-12-1-${NV_CUDA_LIB_VERSION} \
-    cuda-cudart-devel-12-1-${NV_CUDA_CUDART_DEV_VERSION} \
-    ${NV_NVPROF_DEV_PACKAGE} \
-    cuda-nvml-devel-12-1-${NV_NVML_DEV_VERSION} \
-    libcublas-devel-12-1-${NV_LIBCUBLAS_DEV_VERSION} \
+    cuda-command-line-tools-12-8-${NV_CUDA_LIB_VERSION} \
+    cuda-libraries-devel-12-8-${NV_CUDA_LIB_VERSION} \
+    cuda-minimal-build-12-8-${NV_CUDA_LIB_VERSION} \
+    cuda-cudart-devel-12-8-${NV_CUDA_CUDART_DEV_VERSION} \
+    cuda-nvml-devel-12-8-${NV_NVML_DEV_VERSION} \
+    libcublas-devel-12-8-${NV_LIBCUBLAS_DEV_VERSION} \
     ${NV_LIBNPP_DEV_PACKAGE} \
     ${NV_LIBNCCL_DEV_PACKAGE} \
     ${NV_CUDA_NSIGHT_COMPUTE_DEV_PACKAGE} \
+    && if [ "${TARGETARCH}" != "arm64" ]; then \
+        yum install -y ${NV_NVPROF_DEV_PACKAGE}; \
+    fi \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
 ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
-# Install CUDA devel cudnn8 from:
-# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.1.1/ubi9/devel/cudnn8/Dockerfile
-ENV NV_CUDNN_VERSION=8.9.0.131-1
-ENV NV_CUDNN_PACKAGE=libcudnn8-${NV_CUDNN_VERSION}.cuda12.1
-ENV NV_CUDNN_PACKAGE_DEV=libcudnn8-devel-${NV_CUDNN_VERSION}.cuda12.1
+# Install CUDA devel cudnn from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.8.0/ubi9/devel/cudnn/Dockerfile
+ENV NV_CUDNN_VERSION=9.7.0.66-1
+ENV NV_CUDNN_PACKAGE=libcudnn9-cuda-12-${NV_CUDNN_VERSION}
+ENV NV_CUDNN_PACKAGE_DEV=libcudnn9-devel-cuda-12-${NV_CUDNN_VERSION}
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 

--- a/images/runtime/ray/cuda/README.md
+++ b/images/runtime/ray/cuda/README.md
@@ -5,5 +5,5 @@ CUDA enabled container image for Ray in OpenShift AI.
 It includes the following layers:
 * UBI 9
 * Python 3.12
-* CUDA 12.1
+* CUDA 12.8
 * Ray 2.47.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bumping Ray CUDA runtime images to 12.8 to support ARM builds as required by [RHOAIENG-33492](https://issues.redhat.com/browse/RHOAIENG-33492).

## How Has This Been Tested?
* Image built locally and pushed via podman. The `platform` arg was used during build.
* Image used in GPU-enabled RayCluster in RHOAI.
* Sample training script successfully executed as per screenshots.

NOTE: These tests were carried out on the `amd64` version of the image in order to verify in OpenShift. The `arm` version built successfully locally in any case.

<img width="448" height="291" alt="Screenshot 2025-09-05 at 08 58 29" src="https://github.com/user-attachments/assets/f5329e22-6155-40d1-a018-30d88b200344" />
<img width="1375" height="318" alt="Screenshot 2025-09-05 at 09 03 58" src="https://github.com/user-attachments/assets/11bb0669-c3dc-4c12-b97f-9dadeba3717d" />
<img width="1563" height="87" alt="Screenshot 2025-09-05 at 09 04 23" src="https://github.com/user-attachments/assets/118c0356-a8a0-4d37-8508-f0c04e298f93" />


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Ray GPU runtime to CUDA 12.8 with updated CUDA, NCCL, and cuDNN versions for improved compatibility and performance.
  * Added multi-architecture build support (including arm64) and architecture-aware packaging.
  * Updated pipeline image tags and defaults to the new CUDA 12.8 variants.

* **Documentation**
  * Updated README references to the default Ray image and CUDA version to reflect CUDA 12.8 and the latest Ray tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->