### PR TITLE
(fix): enable build index image

### DIFF
--- a/.tekton/ray-cuda-push.yaml
+++ b/.tekton/ray-cuda-push.yaml
@@ -115,7 +115,7 @@ spec:
       description: Build a source image.
       name: build-source-image
       type: string
-    - default: "false"
+    - default: "true"
       description: Add built image into an OCI image index
       name: build-image-index
       type: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the CUDA image build pipeline to publish images with an OCI image index by default. This standardizes outputs across architectures and allows clients to pull the correct variant automatically (e.g., AMD64/ARM64) without manual selection. No user-facing configuration is required, and no public APIs or behaviors were otherwise modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->