### PR TITLE
Use list of users as lake gate approvers

### DIFF
--- a/.github/workflows/approve-lake-gate.yml
+++ b/.github/workflows/approve-lake-gate.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   approve-lake-gate:
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/approve') && contains(github.event.issue.labels.*.name, 'lake-gate') && github.event.comment.author_association == 'OWNER'
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/approve') && contains(github.event.issue.labels.*.name, 'lake-gate')
     
     steps:
     - name: Checkout repository
@@ -24,6 +24,40 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Disallow forks
+      run: |
+        set -euo pipefail
+        PR_NUMBER="${{ github.event.issue.number }}"
+        IS_CROSS=$(gh pr view "$PR_NUMBER" --json isCrossRepository --jq '.isCrossRepository')
+        if [ "$IS_CROSS" = "true" ]; then
+          gh pr comment "$PR_NUMBER" --body "❌ Cannot approve: fork-based PRs are not supported for lake-gate. Please open the PR from a branch in the main repository."
+          exit 1
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check if user is authorized to approve
+      run: |
+        set -euo pipefail
+        COMMENT_USER="${{ github.event.comment.user.login }}"
+        echo "Checking authorization for user: $COMMENT_USER"
+
+        # Check if the user is in the approve-lake-gate alias in OWNERS_ALIASES file
+        if yq eval '.aliases.approve-lake-gate[] | select(. == "'${COMMENT_USER}'")' OWNERS_ALIASES | grep -q "${COMMENT_USER}"; then
+          echo "✅ User ${COMMENT_USER} is authorized to approve lake-gate PRs"
+        else
+          echo "❌ User ${COMMENT_USER} is not authorized to approve lake-gate PRs"
+
+          # Show available approvers for debugging
+          echo "Available approve-lake-gate users:"
+          yq eval '.aliases.approve-lake-gate[]' OWNERS_ALIASES || echo "No approve-lake-gate alias found"
+
+          gh pr comment "${{ github.event.issue.number }}" --body "❌ @${COMMENT_USER} is not authorized to approve lake-gate PRs. Only users listed in the approve-lake-gate alias in OWNERS_ALIASES file can approve."
+          exit 1
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Configure Git
       run: |

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,7 @@
+aliases:
+  approve-lake-gate:
+    - abhijeet-dhumal
+    - ChughShilpa
+    - efazal
+    - kapil27
+    - sutaakar


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use OWNERS_ALIASES file to list GitHub users with rights to approve lake gate PRs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened the lake-gate approval workflow: only PRs with the lake-gate label and a valid /approve from authorized users proceed.
  * Added an authorization check that validates the commenter against a named approvers alias and posts clear feedback if unauthorized.
  * Defined an approvers alias listing authorized approvers.
  * Added a guard that disallows approvals from forked PRs, failing early with a comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->