### PR TITLE
Provide ODH_NAMESPACE env var as part of test image

### DIFF
--- a/images/tests/.env-odh
+++ b/images/tests/.env-odh
@@ -1,2 +1,3 @@
+ODH_NAMESPACE=opendatahub
 FMS_HF_TUNING_IMAGE=quay.io/modh/fms-hf-tuning:release
 NOTEBOOK_IMAGE=quay.io/modh/odh-workbench-jupyter-datascience-cpu-py311-ubi9:rhoai-2.24


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
To fix the shift left test issue - ODH and RHOAI test images need to point to different namespace,

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced a configurable environment variable for the Open Data Hub namespace in the test setup to standardize test environments and reduce configuration drift across runs.
  * No changes to application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->