### PR TITLE
Add MPI GRPO benchmark for multi-node performance testing

### DIFF
--- a/benchmarks/kftv2-mpi-grpo/README.md
+++ b/benchmarks/kftv2-mpi-grpo/README.md
@@ -1,0 +1,171 @@
+# kftv2-mpi-grpo — MPI GRPO Training Benchmark
+
+Multi-node MPI performance benchmark using **GRPO** (Group Relative Policy
+Optimization) to train **Qwen 2.5 7B Instruct** on the **GSM8K** math dataset
+with **DeepSpeed ZeRO-3**.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Algorithm | GRPO via TRL `GRPOTrainer` |
+| Model | `Qwen/Qwen2.5-7B-Instruct` (7 billion parameters) |
+| Dataset | `openai/gsm8k` (~7.5K grade-school math problems) |
+| Reward | Rule-based (answer correctness + format quality) — no reward model needed |
+| Distributed | DeepSpeed ZeRO-3 + OpenMPI via Kubeflow TrainJob |
+| Default scale | 5 nodes x 8 GPUs = **40 A100 80GB GPUs** |
+| Runtime image | `quay.io/ksuta/odh-mpi-cuda:0.0.14` |
+| Training runtime | `odh-mpi-cuda-openmpi-aipcc` (ClusterTrainingRuntime) |
+
+### Why GRPO + GSM8K?
+
+GRPO is a single-model RL algorithm (no separate reward/value/reference models)
+that generates rich MPI communication patterns representative of real
+production training:
+
+| MPI Pattern | Source in GRPO |
+|-------------|---------------|
+| `allreduce` | Gradient synchronisation every training step |
+| `allgather` | ZeRO-3 parameter gathering for forward/backward passes |
+| `broadcast` | Distribution of generation outputs across ranks |
+| `reduce_scatter` | ZeRO-3 gradient partitioning |
+
+This covers 3 of 4 PSAP metric categories (latency, bandwidth, collectives).
+Point-to-point at the API level is covered by the separate OSU micro-benchmarks.
+
+## Prerequisites
+
+- A Kubernetes cluster with GPU nodes (A100 80GB recommended)
+- The `odh-mpi-cuda-openmpi-aipcc` ClusterTrainingRuntime deployed
+- `kubectl` access to the cluster
+- Outbound internet access from pods (to download the model and dataset from
+  HuggingFace on first run)
+
+## Quick Start
+
+```bash
+# 1. Create namespace
+kubectl create namespace kftv2-mpi-grpo
+
+# 2. Create ConfigMap containing the training script and DeepSpeed config
+kubectl create configmap mpi-grpo-scripts \
+  --from-file=train_grpo.py \
+  --from-file=ds_config_zero3.json \
+  -n kftv2-mpi-grpo
+
+# 3. Deploy the TrainJob (default: 5 nodes x 8 GPUs = 40 GPUs)
+kubectl apply -f trainjob.yaml
+
+# 4. Watch training logs
+kubectl logs -n kftv2-mpi-grpo \
+  -l batch.kubernetes.io/job-name=mpi-grpo-benchmark-launcher-0 \
+  --tail=-1 -f
+```
+
+## Scaling
+
+Edit `trainjob.yaml` to adjust the number of nodes and GPUs per node:
+
+| Configuration | `numNodes` | `nvidia.com/gpu` | `memory` | `cpu` | Total GPUs |
+|---------------|-----------|-----------------|---------|------|-----------|
+| Full benchmark | 5 | 8 | 200Gi | 32 | 40 |
+| Medium | 2 | 8 | 200Gi | 32 | 16 |
+| Smoke test | 2 | 1 | 40Gi | 8 | 2 |
+
+For 13B+ models, increase `memory` to 300Gi and consider reducing
+`GRPO_BATCH_SIZE` to avoid OOM.
+
+## Configuration
+
+All training parameters are tuneable via environment variables passed through
+`mpirun -x` in the TrainJob command. Edit the `mpirun` block in
+`trainjob.yaml`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRPO_MODEL` | `Qwen/Qwen2.5-7B-Instruct` | HuggingFace model ID |
+| `GRPO_MAX_STEPS` | `50` | Number of training steps |
+| `GRPO_BATCH_SIZE` | `1` | Per-device batch size |
+| `GRPO_NUM_GENERATIONS` | `4` | Completions generated per prompt |
+| `GRPO_DATASET_SIZE` | (all ~7.5K) | Number of GSM8K examples; empty = full dataset |
+| `GRPO_MAX_COMPLETION` | `512` | Maximum tokens per completion |
+| `GRPO_MAX_PROMPT` | `256` | Maximum prompt tokens |
+| `GRPO_DS_CONFIG` | `/mnt/scripts/ds_config_zero3.json` | DeepSpeed config path |
+| `GRPO_LEARNING_RATE` | `5e-7` | Learning rate |
+| `GRPO_LOG_FREQ` | `1` | Log benchmark metrics every N steps |
+
+### Estimated Run Times
+
+Based on spike validation (Qwen 2.5 7B, DeepSpeed ZeRO-3):
+
+| Scale | Step Time (approx) | 50 Steps |
+|-------|-------------------|---------|
+| 2 x 1 GPU | ~41 s/step | ~35 min |
+| 2 x 8 GPUs | ~15-25 s/step | ~15-20 min |
+| 5 x 8 GPUs | ~10-20 s/step | ~10-15 min |
+
+Step time varies with batch size, generation length, and inter-node network
+bandwidth. Increase `GRPO_MAX_STEPS` for longer runs if needed.
+
+## Benchmark Output
+
+The training script automatically logs per-step metrics and prints a summary
+at the end:
+
+```
+[Benchmark] step=3 step_time=38.42s samples/s=1.04 gpu_mem_alloc=27.3GB gpu_mem_reserved=31.2GB
+...
+============================================================
+BENCHMARK RESULTS
+============================================================
+  Model:              Qwen/Qwen2.5-7B-Instruct
+  World size:         40 GPUs
+  Batch size/device:  1
+  Global batch size:  40
+  Num generations:    4
+  DeepSpeed config:   /mnt/scripts/ds_config_zero3.json
+  Total steps:        50
+  Total time:         842.1s (14.0 min)
+  Warmup steps:       2
+  Avg step time:      16.84s (post-warmup)
+  Min step time:      15.21s
+  Max step time:      19.47s
+  Avg throughput:     2.38 samples/s
+  Peak GPU memory:    34.2GB
+============================================================
+```
+
+Key metrics for perf analysis:
+- **Avg step time** — end-to-end per-step duration (compute + communication)
+- **Throughput** — samples/sec across all GPUs
+- **Peak GPU memory** — maximum allocated GPU memory per device
+- **Step time variance** (min/max) — indicates communication jitter
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `train_grpo.py` | GRPO training script with benchmark instrumentation |
+| `ds_config_zero3.json` | DeepSpeed ZeRO Stage 3 configuration |
+| `trainjob.yaml` | Kubeflow TrainJob manifest |
+| `README.md` | This file |
+
+## Known Issues and Workarounds
+
+These issues were discovered during the spike validation and are already
+handled in the training script and TrainJob manifest:
+
+| Issue | Workaround |
+|-------|-----------|
+| DeepSpeed `nvcc` not found | `train_grpo.py` creates a stub at `/tmp/cuda_stub/bin/nvcc` |
+| SSH key permissions (0644 instead of required 0600) | Launcher copies key to `/tmp/id_rsa` with `chmod 600` |
+| NCCL `/dev/shm` too small (K8s default is 64MB) | `emptyDir` with `medium: Memory` mounted at `/dev/shm` (16Gi) |
+| Pods landing on same node | `podAntiAffinity` on `jobset.sigs.k8s.io/jobset-name` label |
+
+## Cleanup
+
+```bash
+kubectl delete trainjob mpi-grpo-benchmark -n kftv2-mpi-grpo
+kubectl delete configmap mpi-grpo-scripts -n kftv2-mpi-grpo
+kubectl delete namespace kftv2-mpi-grpo
+```

--- a/benchmarks/kftv2-mpi-grpo/ds_config_zero3.json
+++ b/benchmarks/kftv2-mpi-grpo/ds_config_zero3.json
@@ -1,0 +1,18 @@
+{
+  "bf16": {
+    "enabled": true
+  },
+  "zero_optimization": {
+    "stage": 3,
+    "overlap_comm": true,
+    "contiguous_gradients": true,
+    "reduce_bucket_size": "auto",
+    "stage3_prefetch_bucket_size": "auto",
+    "stage3_param_persistence_threshold": "auto",
+    "stage3_gather_16bit_weights_on_model_save": true
+  },
+  "gradient_accumulation_steps": "auto",
+  "gradient_clipping": "auto",
+  "train_batch_size": "auto",
+  "train_micro_batch_size_per_gpu": "auto"
+}

--- a/benchmarks/kftv2-mpi-grpo/train_grpo.py
+++ b/benchmarks/kftv2-mpi-grpo/train_grpo.py
@@ -3,7 +3,8 @@
 MPI GRPO Benchmark — Qwen 2.5 7B + GSM8K + DeepSpeed ZeRO-3
 
 Production benchmark for validating multi-node MPI network performance.
-Designed for up to 5 nodes x 8 GPUs = 40 A100 80GB GPUs.
+Target hardware: IBMCloud gx3d-160x1792x8h100 (8x H100 80GB per node).
+Scaling strategy: 1/2/4 nodes (8-32 GPUs), extrapolated to 16 nodes (128 GPUs).
 
 Launch via mpirun (handled by Kubeflow TrainJob MPI runtime):
     mpirun -x MASTER_ADDR=... -x MASTER_PORT=29500 python train_grpo.py

--- a/benchmarks/kftv2-mpi-grpo/train_grpo.py
+++ b/benchmarks/kftv2-mpi-grpo/train_grpo.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+MPI GRPO Benchmark — Qwen 2.5 7B + GSM8K + DeepSpeed ZeRO-3
+
+Production benchmark for validating multi-node MPI network performance.
+Designed for up to 5 nodes x 8 GPUs = 40 A100 80GB GPUs.
+
+Launch via mpirun (handled by Kubeflow TrainJob MPI runtime):
+    mpirun -x MASTER_ADDR=... -x MASTER_PORT=29500 python train_grpo.py
+
+Environment variables:
+    GRPO_MODEL           HuggingFace model ID       (default: Qwen/Qwen2.5-7B-Instruct)
+    GRPO_MAX_STEPS       Training steps              (default: 50)
+    GRPO_BATCH_SIZE      Per-device batch size       (default: 1)
+    GRPO_NUM_GENERATIONS Completions per prompt      (default: 4)
+    GRPO_DATASET_SIZE    GSM8K examples to use       (default: all ~7.5K)
+    GRPO_MAX_COMPLETION  Max completion tokens       (default: 512)
+    GRPO_MAX_PROMPT      Max prompt tokens           (default: 256)
+    GRPO_DS_CONFIG       DeepSpeed config path       (default: disabled)
+    GRPO_LEARNING_RATE   Learning rate               (default: 5e-7)
+    GRPO_LOG_FREQ        Log every N steps           (default: 1)
+"""
+
+import os
+import re
+import socket
+import time
+
+# ---------------------------------------------------------------------------
+# MPI -> PyTorch environment bridging
+# OpenMPI sets OMPI_COMM_WORLD_* variables; map them to the RANK/LOCAL_RANK/
+# WORLD_SIZE that PyTorch distributed and HuggingFace Accelerate expect.
+# ---------------------------------------------------------------------------
+rank = int(os.environ.get("OMPI_COMM_WORLD_RANK", "0"))
+local_rank = int(os.environ.get("OMPI_COMM_WORLD_LOCAL_RANK", "0"))
+world_size = int(os.environ.get("OMPI_COMM_WORLD_SIZE", "1"))
+
+os.environ.setdefault("RANK", str(rank))
+os.environ.setdefault("LOCAL_RANK", str(local_rank))
+os.environ.setdefault("WORLD_SIZE", str(world_size))
+os.environ.setdefault("MASTER_PORT", "29500")
+os.environ.setdefault("HF_HOME", "/tmp/hf_cache")
+
+# ---------------------------------------------------------------------------
+# nvcc stub workaround
+# The runtime image (quay.io/ksuta/odh-mpi-cuda:0.0.14) ships CUDA runtime
+# libraries but not the full CUDA toolkit. DeepSpeed's module-level import
+# runs `nvcc -V` and fails without it. Create a minimal stub.
+# ---------------------------------------------------------------------------
+_nvcc_dir = "/tmp/cuda_stub/bin"
+os.makedirs(_nvcc_dir, exist_ok=True)
+_nvcc_path = os.path.join(_nvcc_dir, "nvcc")
+if not os.path.exists(_nvcc_path):
+    with open(_nvcc_path, "w") as f:
+        f.write(
+            '#!/bin/bash\n'
+            'echo "Cuda compilation tools, release 13.0, V13.0.76"\n'
+        )
+    os.chmod(_nvcc_path, 0o755)
+os.environ["CUDA_HOME"] = "/tmp/cuda_stub"
+
+hostname = socket.gethostname()
+if rank == 0:
+    print(f"{'=' * 60}", flush=True)
+    print("MPI GRPO Benchmark", flush=True)
+    print(f"{'=' * 60}", flush=True)
+print(
+    f"[Rank {rank}/{world_size}] host={hostname} local_rank={local_rank}",
+    flush=True,
+)
+
+# ---------------------------------------------------------------------------
+# Imports (must come after nvcc stub so DeepSpeed import doesn't crash)
+# ---------------------------------------------------------------------------
+import torch  # noqa: E402
+from datasets import load_dataset  # noqa: E402
+from trl import GRPOConfig, GRPOTrainer  # noqa: E402
+from transformers import TrainerCallback  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Configuration (all tuneable via env vars)
+# ---------------------------------------------------------------------------
+MODEL_NAME = os.environ.get("GRPO_MODEL", "Qwen/Qwen2.5-7B-Instruct")
+MAX_STEPS = int(os.environ.get("GRPO_MAX_STEPS", "50"))
+BATCH_SIZE = int(os.environ.get("GRPO_BATCH_SIZE", "1"))
+NUM_GENERATIONS = int(os.environ.get("GRPO_NUM_GENERATIONS", "4"))
+DATASET_SIZE = os.environ.get("GRPO_DATASET_SIZE", "")
+MAX_COMPLETION = int(os.environ.get("GRPO_MAX_COMPLETION", "512"))
+MAX_PROMPT = int(os.environ.get("GRPO_MAX_PROMPT", "256"))
+DS_CONFIG = os.environ.get("GRPO_DS_CONFIG", "")
+LEARNING_RATE = float(os.environ.get("GRPO_LEARNING_RATE", "5e-7"))
+LOG_FREQ = int(os.environ.get("GRPO_LOG_FREQ", "1"))
+
+
+# ---------------------------------------------------------------------------
+# Benchmark metrics callback
+# ---------------------------------------------------------------------------
+class BenchmarkMetricsCallback(TrainerCallback):
+    """Tracks per-step timing and GPU memory for benchmark analysis.
+
+    Prints a per-step log line and a final summary table. The first two
+    steps are treated as warmup and excluded from the steady-state averages.
+    """
+
+    WARMUP_STEPS = 2
+
+    def __init__(self):
+        self.step_start = None
+        self.step_times = []
+        self.train_start = None
+
+    def on_train_begin(self, args, state, control, **kwargs):
+        self.train_start = time.time()
+        if rank == 0:
+            alloc = torch.cuda.memory_allocated(local_rank) / 1e9
+            reserved = torch.cuda.memory_reserved(local_rank) / 1e9
+            print(
+                f"[Benchmark] GPU memory at train start: "
+                f"allocated={alloc:.1f}GB reserved={reserved:.1f}GB",
+                flush=True,
+            )
+
+    def on_step_begin(self, args, state, control, **kwargs):
+        self.step_start = time.time()
+
+    def on_step_end(self, args, state, control, **kwargs):
+        if self.step_start is None:
+            return
+        elapsed = time.time() - self.step_start
+        self.step_times.append(elapsed)
+
+        if rank == 0 and state.global_step % LOG_FREQ == 0:
+            alloc = torch.cuda.memory_allocated(local_rank) / 1e9
+            reserved = torch.cuda.memory_reserved(local_rank) / 1e9
+            samples_per_sec = (BATCH_SIZE * world_size) / elapsed
+            print(
+                f"[Benchmark] step={state.global_step} "
+                f"step_time={elapsed:.2f}s "
+                f"samples/s={samples_per_sec:.2f} "
+                f"gpu_mem_alloc={alloc:.1f}GB "
+                f"gpu_mem_reserved={reserved:.1f}GB",
+                flush=True,
+            )
+
+    def on_train_end(self, args, state, control, **kwargs):
+        if rank != 0 or not self.step_times:
+            return
+
+        total_time = time.time() - self.train_start
+        warmup = min(self.WARMUP_STEPS, len(self.step_times))
+        steady = self.step_times[warmup:]
+        avg_step = sum(steady) / len(steady) if steady else 0
+        min_step = min(steady) if steady else 0
+        max_step = max(steady) if steady else 0
+        throughput = (BATCH_SIZE * world_size) / avg_step if avg_step > 0 else 0
+        peak_mem = torch.cuda.max_memory_allocated(local_rank) / 1e9
+
+        print(f"\n{'=' * 60}", flush=True)
+        print("BENCHMARK RESULTS", flush=True)
+        print(f"{'=' * 60}", flush=True)
+        print(f"  Model:              {MODEL_NAME}", flush=True)
+        print(f"  World size:         {world_size} GPUs", flush=True)
+        print(f"  Batch size/device:  {BATCH_SIZE}", flush=True)
+        print(f"  Global batch size:  {BATCH_SIZE * world_size}", flush=True)
+        print(f"  Num generations:    {NUM_GENERATIONS}", flush=True)
+        print(f"  DeepSpeed config:   {DS_CONFIG or 'disabled'}", flush=True)
+        print(f"  Total steps:        {state.global_step}", flush=True)
+        print(
+            f"  Total time:         {total_time:.1f}s ({total_time / 60:.1f} min)",
+            flush=True,
+        )
+        print(f"  Warmup steps:       {warmup}", flush=True)
+        print(f"  Avg step time:      {avg_step:.2f}s (post-warmup)", flush=True)
+        print(f"  Min step time:      {min_step:.2f}s", flush=True)
+        print(f"  Max step time:      {max_step:.2f}s", flush=True)
+        print(f"  Avg throughput:     {throughput:.2f} samples/s", flush=True)
+        print(f"  Peak GPU memory:    {peak_mem:.1f}GB", flush=True)
+        print(f"{'=' * 60}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Reward functions
+# ---------------------------------------------------------------------------
+def reward_correctness(completions, answer, **kwargs):
+    """Binary reward: 1.0 if the model's final number matches GSM8K ground truth."""
+    rewards = []
+    for completion, gt in zip(completions, answer):
+        content = completion[0]["content"] if isinstance(completion, list) else completion
+        gt_match = re.search(r"####\s*([\d,]+)", gt)
+        gt_num = gt_match.group(1).replace(",", "") if gt_match else ""
+        pred_nums = re.findall(r"[\d,]+", content)
+        if gt_num and pred_nums and pred_nums[-1].replace(",", "") == gt_num:
+            rewards.append(1.0)
+        else:
+            rewards.append(0.0)
+    return rewards
+
+
+def reward_format(completions, **kwargs):
+    """Small reward for showing step-by-step reasoning."""
+    rewards = []
+    for completion in completions:
+        content = completion[0]["content"] if isinstance(completion, list) else completion
+        has_steps = bool(
+            re.search(r"step|therefore|so |thus |=", content, re.IGNORECASE)
+        )
+        rewards.append(0.5 if has_steps else 0.0)
+    return rewards
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+if rank == 0:
+    print("Loading GSM8K dataset...", flush=True)
+
+split = f"train[:{DATASET_SIZE}]" if DATASET_SIZE else "train"
+dataset = load_dataset("openai/gsm8k", "main", split=split)
+
+SYSTEM_PROMPT = (
+    "You are a math tutor. Solve the problem step by step, "
+    "then give the final numerical answer after '####'."
+)
+
+
+def format_prompt(example):
+    return {
+        "prompt": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": example["question"]},
+        ]
+    }
+
+
+dataset = dataset.map(format_prompt)
+
+if rank == 0:
+    print(f"Dataset loaded: {len(dataset)} examples", flush=True)
+
+# ---------------------------------------------------------------------------
+# Training
+# ---------------------------------------------------------------------------
+if rank == 0:
+    print(f"\nTraining configuration:", flush=True)
+    print(f"  Model:            {MODEL_NAME}", flush=True)
+    print(f"  World size:       {world_size}", flush=True)
+    print(f"  Batch/device:     {BATCH_SIZE}", flush=True)
+    print(f"  Num generations:  {NUM_GENERATIONS}", flush=True)
+    print(f"  Max steps:        {MAX_STEPS}", flush=True)
+    print(f"  Max completion:   {MAX_COMPLETION}", flush=True)
+    print(f"  Max prompt:       {MAX_PROMPT}", flush=True)
+    print(f"  Learning rate:    {LEARNING_RATE}", flush=True)
+    print(f"  DeepSpeed:        {DS_CONFIG or 'disabled'}", flush=True)
+    print(f"  Dataset size:     {len(dataset)}", flush=True)
+
+training_args = GRPOConfig(
+    output_dir="/tmp/grpo_output",
+    per_device_train_batch_size=BATCH_SIZE,
+    num_generations=NUM_GENERATIONS,
+    max_completion_length=MAX_COMPLETION,
+    max_prompt_length=MAX_PROMPT,
+    max_steps=MAX_STEPS,
+    logging_steps=LOG_FREQ,
+    learning_rate=LEARNING_RATE,
+    bf16=True,
+    gradient_checkpointing=True,
+    save_strategy="no",
+    report_to="none",
+    deepspeed=DS_CONFIG if DS_CONFIG else None,
+)
+
+trainer = GRPOTrainer(
+    model=MODEL_NAME,
+    reward_funcs=[reward_correctness, reward_format],
+    args=training_args,
+    train_dataset=dataset,
+    callbacks=[BenchmarkMetricsCallback()],
+)
+
+trainer.train()
+
+if rank == 0:
+    print("\n=== GRPO TRAINING COMPLETE ===", flush=True)

--- a/benchmarks/kftv2-mpi-grpo/trainjob.yaml
+++ b/benchmarks/kftv2-mpi-grpo/trainjob.yaml
@@ -1,0 +1,141 @@
+# MPI GRPO Benchmark — Qwen 2.5 7B + GSM8K + DeepSpeed ZeRO-3
+# 5 nodes x 8 A100 80GB GPUs = 40 GPUs total
+#
+# Algorithm:  GRPO (Group Relative Policy Optimization) via TRL GRPOTrainer
+# Model:      Qwen/Qwen2.5-7B-Instruct
+# Dataset:    openai/gsm8k (~7.5K grade-school math problems)
+# Distributed: DeepSpeed ZeRO-3 + OpenMPI via Kubeflow TrainJob
+#
+# MPI communication patterns exercised:
+#   - allreduce   (gradient synchronisation every step)
+#   - allgather   (ZeRO-3 parameter gathering for forward/backward)
+#   - broadcast   (generation output distribution across ranks)
+#
+# Prerequisites:
+#   kubectl create namespace kftv2-mpi-grpo
+#   kubectl create configmap mpi-grpo-scripts \
+#     --from-file=train_grpo.py \
+#     --from-file=ds_config_zero3.json \
+#     -n kftv2-mpi-grpo
+#
+# Run:
+#   kubectl apply -f trainjob.yaml
+#
+# Logs:
+#   kubectl logs -n kftv2-mpi-grpo \
+#     -l batch.kubernetes.io/job-name=mpi-grpo-benchmark-launcher-0 \
+#     --tail=-1 -f
+#
+# Scaling:
+#   - 40 GPUs (default):  numNodes: 5, nvidia.com/gpu: "8"
+#   - 16 GPUs:            numNodes: 2, nvidia.com/gpu: "8"
+#   - 2 GPUs (smoke):     numNodes: 2, nvidia.com/gpu: "1", memory: 40Gi, cpu: "8"
+#   For 13B+ models increase memory to 300Gi and consider reducing GRPO_BATCH_SIZE.
+---
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: mpi-grpo-benchmark
+  namespace: kftv2-mpi-grpo
+spec:
+  runtimeRef:
+    apiGroup: trainer.kubeflow.org
+    kind: ClusterTrainingRuntime
+    name: odh-mpi-cuda-openmpi-aipcc
+  trainer:
+    command:
+    - bash
+    - -c
+    - |
+      echo "=== MPI GRPO Benchmark — Launcher ==="
+      echo "Hostname: $(hostname -f)"
+      echo "Hostfile:"
+      cat /etc/mpi/hostfile 2>/dev/null || echo "No hostfile"
+      echo "GPU count per node: $(nvidia-smi -L 2>/dev/null | wc -l)"
+      echo "---"
+
+      # Workaround: Kubernetes mounts SSH secret volumes with 0644 permissions
+      # but SSH requires 0600 for private keys.
+      echo "Fixing SSH key permissions..."
+      cp /home/mpiuser/.ssh/id_rsa /tmp/id_rsa && chmod 600 /tmp/id_rsa
+
+      echo "Waiting 30s for workers to be ready..."
+      sleep 30
+
+      mpirun --mca plm_rsh_args "-i /tmp/id_rsa -o ConnectionAttempts=10" \
+        -x MASTER_ADDR=$(hostname -f) \
+        -x MASTER_PORT=29500 \
+        -x HF_HOME=/tmp/hf_cache \
+        -x NCCL_DEBUG=INFO \
+        -x GRPO_MODEL=Qwen/Qwen2.5-7B-Instruct \
+        -x GRPO_MAX_STEPS=50 \
+        -x GRPO_BATCH_SIZE=1 \
+        -x GRPO_NUM_GENERATIONS=4 \
+        -x GRPO_MAX_COMPLETION=512 \
+        -x GRPO_MAX_PROMPT=256 \
+        -x GRPO_LEARNING_RATE=5e-7 \
+        -x GRPO_DS_CONFIG=/mnt/scripts/ds_config_zero3.json \
+        python /mnt/scripts/train_grpo.py
+    numNodes: 5
+    resourcesPerNode:
+      limits:
+        nvidia.com/gpu: "8"
+        memory: 200Gi
+        cpu: "32"
+      requests:
+        nvidia.com/gpu: "8"
+        memory: 200Gi
+        cpu: "32"
+  podTemplateOverrides:
+  # --- launcher pod ---
+  - spec:
+      containers:
+      - name: node
+        volumeMounts:
+        - mountPath: /mnt/scripts
+          name: scripts
+        - mountPath: /dev/shm
+          name: dshm
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                jobset.sigs.k8s.io/jobset-name: mpi-grpo-benchmark
+            topologyKey: kubernetes.io/hostname
+      volumes:
+      - name: scripts
+        configMap:
+          name: mpi-grpo-scripts
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 16Gi
+    targetJobs:
+    - name: launcher
+  # --- worker pods ---
+  - spec:
+      containers:
+      - name: node
+        volumeMounts:
+        - mountPath: /mnt/scripts
+          name: scripts
+        - mountPath: /dev/shm
+          name: dshm
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                jobset.sigs.k8s.io/jobset-name: mpi-grpo-benchmark
+            topologyKey: kubernetes.io/hostname
+      volumes:
+      - name: scripts
+        configMap:
+          name: mpi-grpo-scripts
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 16Gi
+    targetJobs:
+    - name: node

--- a/benchmarks/kftv2-mpi-grpo/trainjob.yaml
+++ b/benchmarks/kftv2-mpi-grpo/trainjob.yaml
@@ -1,10 +1,11 @@
 # MPI GRPO Benchmark — Qwen 2.5 7B + GSM8K + DeepSpeed ZeRO-3
-# 5 nodes x 8 A100 80GB GPUs = 40 GPUs total
+# Target: IBMCloud gx3d-160x1792x8h100 nodes (8x H100 80GB per node)
 #
 # Algorithm:  GRPO (Group Relative Policy Optimization) via TRL GRPOTrainer
 # Model:      Qwen/Qwen2.5-7B-Instruct
 # Dataset:    openai/gsm8k (~7.5K grade-school math problems)
 # Distributed: DeepSpeed ZeRO-3 + OpenMPI via Kubeflow TrainJob
+# Network:    150 Gbps RoCE
 #
 # MPI communication patterns exercised:
 #   - allreduce   (gradient synchronisation every step)
@@ -26,11 +27,11 @@
 #     -l batch.kubernetes.io/job-name=mpi-grpo-benchmark-launcher-0 \
 #     --tail=-1 -f
 #
-# Scaling:
-#   - 40 GPUs (default):  numNodes: 5, nvidia.com/gpu: "8"
-#   - 16 GPUs:            numNodes: 2, nvidia.com/gpu: "8"
-#   - 2 GPUs (smoke):     numNodes: 2, nvidia.com/gpu: "1", memory: 40Gi, cpu: "8"
-#   For 13B+ models increase memory to 300Gi and consider reducing GRPO_BATCH_SIZE.
+# Scaling strategy (8xH100 per node):
+#   - 1 node  (  8 GPUs):  numNodes: 1  — default
+#   - 2 nodes ( 16 GPUs):  numNodes: 2  — first inter-node scaling point
+#   - 4 nodes ( 32 GPUs):  numNodes: 4  — mid-scale benchmark
+#   - 16 nodes (128 GPUs): numNodes: 16 — extrapolation target
 ---
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: TrainJob
@@ -67,6 +68,9 @@ spec:
         -x MASTER_PORT=29500 \
         -x HF_HOME=/tmp/hf_cache \
         -x NCCL_DEBUG=INFO \
+        -x NCCL_IB_DISABLE=0 \
+        -x NCCL_NET_GDR_LEVEL=5 \
+        -x NCCL_IB_GID_INDEX=3 \
         -x GRPO_MODEL=Qwen/Qwen2.5-7B-Instruct \
         -x GRPO_MAX_STEPS=50 \
         -x GRPO_BATCH_SIZE=1 \
@@ -76,16 +80,16 @@ spec:
         -x GRPO_LEARNING_RATE=5e-7 \
         -x GRPO_DS_CONFIG=/mnt/scripts/ds_config_zero3.json \
         python /mnt/scripts/train_grpo.py
-    numNodes: 5
+    numNodes: 1
     resourcesPerNode:
       limits:
         nvidia.com/gpu: "8"
-        memory: 200Gi
-        cpu: "32"
+        memory: 1200Gi
+        cpu: "120"
       requests:
         nvidia.com/gpu: "8"
-        memory: 200Gi
-        cpu: "32"
+        memory: 1200Gi
+        cpu: "120"
   podTemplateOverrides:
   # --- launcher pod ---
   - spec:


### PR DESCRIPTION
Resolves [RHOAIENG-51103](https://redhat.atlassian.net/browse/RHOAIENG-51103)

## Description
Add MPI GRPO benchmark for multi-node performance testing

## How Has This Been Tested?
The trainjob.yaml defaults to 5 nodes x 8 GPUs = 40 GPUs, which is the perf team's target. That specific configuration hasn't been tested — it's the perf team's cluster that has the capacity for it.

So to be precise: the training script logic (GRPO + GSM8K + DeepSpeed ZeRO-3 + MPI) is validated end-to-end on 2 nodes. The scaling to 40 GPUs is a parameter change (numNodes: 5, nvidia.com/gpu: "8") that DeepSpeed ZeRO-3 handles transparently — but it hasn't been physically run at that scale yet.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MPI-based GRPO training benchmark for multi-node multi-GPU LLM fine-tuning with DeepSpeed ZeRO-3 and runtime scaling controls, plus automated runtime fixes and per-step metric capture.

* **Documentation**
  * Added a full benchmark guide covering setup, quick-start deployment, scaling guidance, environment variables, estimated run times, example outputs, cleanup steps, and known-issue workarounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->