### PR TITLE
Use CPU runtime for CPU tests instead of CUDA runtime

### DIFF
--- a/tests/trainer/kubeflow_sdk_test.go
+++ b/tests/trainer/kubeflow_sdk_test.go
@@ -156,7 +156,9 @@ func TestRhaiFeaturesMultiGpuRocm(t *testing.T) {
 	sdktests.RunRhaiFeaturesAllMultiGpuTest(t, support.AMD, 2, 2)
 }
 
-// Training Failure Scenarios (CPU only) — verifies failures are properly propagated
+// Training Failure Scenarios — verifies failures are properly propagated
+// Requires CUDA: LORA scenario uses Unsloth which fails at import without CUDA,
+// producing a different error than the expected "No config file found".
 func TestTrainingFailureScenarios(t *testing.T) {
 	Tags(t, KftoCuda, Gpu(support.NVIDIA))
 	sdktests.RunTrainingFailureScenariosTest(t)

--- a/tests/trainer/sdk_tests/fashion_mnist_tests.go
+++ b/tests/trainer/sdk_tests/fashion_mnist_tests.go
@@ -109,8 +109,7 @@ func RunFashionMnistCpuDistributedTraining(t *testing.T) {
 			"then echo 'NOTEBOOK_STATUS: SUCCESS'; else echo 'NOTEBOOK_STATUS: FAILURE'; fi; sleep infinity",
 		shellQuote(support.GetOpenShiftApiUrl(test)), shellQuote(userToken), shellQuote(namespace.Name), shellQuote(rwxPvc.Name),
 		shellQuote(endpoint), shellQuote(accessKey), shellQuote(secretKey), shellQuote(bucket), shellQuote(prefix),
-		// TODO: change to DefaultClusterTrainingRuntimeCPU for EA2 RC2 and later
-		shellQuote(trainerutils.DefaultClusterTrainingRuntimeCUDA),
+		shellQuote(trainerutils.DefaultClusterTrainingRuntimeCPU),
 		sdkInstallExports,
 		installKubeflowScript,
 		notebookName,
@@ -241,8 +240,7 @@ func RunFashionMnistKueueCpuDistributedTraining(t *testing.T) {
 			"then echo 'NOTEBOOK_STATUS: SUCCESS'; else echo 'NOTEBOOK_STATUS: FAILURE'; fi; sleep infinity",
 		shellQuote(support.GetOpenShiftApiUrl(test)), shellQuote(userToken), shellQuote(namespace.Name), shellQuote(rwxPvc.Name),
 		shellQuote(endpoint), shellQuote(accessKey), shellQuote(secretKey), shellQuote(bucket), shellQuote(prefix),
-		// TODO: change to DefaultClusterTrainingRuntimeCPU for EA2 RC2 and later
-		shellQuote(trainerutils.DefaultClusterTrainingRuntimeCUDA),
+		shellQuote(trainerutils.DefaultClusterTrainingRuntimeCPU),
 		shellQuote(customLocalQueue.Name),
 		sdkInstallExports,
 		installKubeflowScript,

--- a/tests/trainer/sdk_tests/rhai_features_tests.go
+++ b/tests/trainer/sdk_tests/rhai_features_tests.go
@@ -291,14 +291,20 @@ func runRhaiFeaturesTestWithConfig(t *testing.T, config RhaiFeatureConfig) {
 	enableProgression := boolStr(config.EnableProgressionTracking)
 	enableCheckpoint := boolStr(config.EnableJitCheckpoint)
 
-	// Determine GPU resource label (empty for CPU) and training runtime
+	// Determine GPU resource label and training runtime based on accelerator
 	gpuResourceLabel := ""
-	trainingRuntime := trainerutils.DefaultClusterTrainingRuntimeCUDA // Default for CPU and NVIDIA
-	if config.Accelerator.IsGpu() {
+	var trainingRuntime string
+	switch config.Accelerator {
+	case CPU:
+		trainingRuntime = trainerutils.DefaultClusterTrainingRuntimeCPU
+	case NVIDIA:
 		gpuResourceLabel = config.Accelerator.ResourceLabel
-		if config.Accelerator == AMD {
-			trainingRuntime = trainerutils.DefaultClusterTrainingRuntimeROCm
-		}
+		trainingRuntime = trainerutils.DefaultClusterTrainingRuntimeCUDA
+	case AMD:
+		gpuResourceLabel = config.Accelerator.ResourceLabel
+		trainingRuntime = trainerutils.DefaultClusterTrainingRuntimeROCm
+	default:
+		t.Fatalf("unsupported accelerator: %+v", config.Accelerator)
 	}
 
 	// S3/MinIO configuration for disconnected environments (optional)


### PR DESCRIPTION
## Summary
- Switch `RunFashionMnistCpuDistributedTraining` and `RunFashionMnistKueueCpuDistributedTraining` from `DefaultClusterTrainingRuntimeCUDA` to `DefaultClusterTrainingRuntimeCPU`, removing the EA2 workaround TODOs
- Fix `runRhaiFeaturesTestWithConfig` to select runtime based on accelerator type via explicit switch (CPU/NVIDIA/AMD) instead of defaulting to CUDA for both CPU and NVIDIA
- Update stale comment on `TestTrainingFailureScenarios` to explain why it requires CUDA (Unsloth import in LORA scenario)

## Test plan
- [x] Run `TestKubeflowSdkSanity` on a CPU-only cluster to verify it uses `torch-distributed-cpu`
- [x] Run `TestRhaiFeaturesCPU` to verify CPU runtime selection
- [x] Run `TestRhaiFeaturesCuda` to verify NVIDIA runtime selection unchanged
- [x] Run `TestRhaiFeaturesRocm` to verify ROCm runtime selection unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated training test configurations to correctly specify CPU runtime settings in distributed training scenarios.
  * Improved accelerator detection logic to explicitly handle CPU, NVIDIA GPU, and AMD GPU configurations with appropriate runtime assignments.
  * Enhanced test documentation and error handling for unsupported accelerator types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->