### PR TITLE
Add MPI benchmark with SFT+DDP

### DIFF
--- a/benchmarks/kftv2-mpi-ddp-sft-ddp/1.5b/README.md
+++ b/benchmarks/kftv2-mpi-ddp-sft-ddp/1.5b/README.md
@@ -1,0 +1,161 @@
+# MPI DDP SFT Benchmark — Qwen 2.5 1.5B
+
+Distributed Supervised Fine-Tuning benchmark using **PyTorch DDP** with **MPI** as the communications backend, submitted via Kubeflow Trainer v2 `TrainJob`.
+
+## What this benchmark does
+
+| Aspect | Details |
+|--------|---------|
+| Algorithm | SFT with PyTorch DistributedDataParallel (DDP) |
+| Model | Qwen/Qwen2.5-1.5B-Instruct (1.5B params, float32) |
+| Dataset | openai/gsm8k (~7.5 K grade-school math) |
+| Comm backend | **MPI** (`torch.distributed.init_process_group(backend="mpi")`) |
+| Gradient sync | DDP automatic allreduce via MPI |
+| Runtime | `mpi-cuda-openmpi-benchmark` ClusterTrainingRuntime |
+| Image | `quay.io/ksuta/odh-mpi-cuda:0.0.14` |
+
+### MPI communication patterns exercised
+
+- **allreduce** — DDP gradient synchronisation every backward pass
+- **broadcast** — DDP parameter broadcast during initialisation
+- **barrier** — rank-0-first model download coordination
+
+### Why float32
+
+The MPI backend in this image only supports `float32` for CUDA collective operations. `float16` and `bfloat16` fail with `IndexError: map::at` due to missing MPI datatype mappings. See the [Known issues](#known-issues) section for details.
+
+### Why 1.5B model
+
+PyTorch DDP groups all gradients into a single flat buffer for the first training step. For models with more than ~2.1B `float32` parameters, the total element count exceeds MPI's `int32` count limit, causing `MPI_ERR_COUNT: invalid count argument`. The 1.5B model (~1.54B parameters) fits within this limit.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `train_sft_ddp.py` | Training script — SFT with DDP + MPI gradient allreduce |
+| `trainjob.yaml` | Kubeflow Trainer v2 TrainJob manifest |
+| `mpi-runtime.yaml` | ClusterTrainingRuntime for MPI + CUDA (OpenMPI) |
+
+## Quick Start
+
+### 1. Deploy the ClusterTrainingRuntime
+
+```bash
+oc apply -f mpi-runtime.yaml
+```
+
+### 2. Create namespace and ConfigMap
+
+```bash
+oc create namespace kftv2-mpi-ddp-sft
+
+oc create configmap mpi-ddp-sft-scripts \
+  --from-file=train_sft_ddp.py \
+  -n kftv2-mpi-ddp-sft
+```
+
+### 3. Submit the TrainJob
+
+```bash
+oc create -f trainjob.yaml
+```
+
+### 4. Monitor
+
+```bash
+# Watch pod status
+oc get pods -n kftv2-mpi-ddp-sft -w
+
+# Stream launcher logs (training output)
+oc logs -n kftv2-mpi-ddp-sft \
+  -l batch.kubernetes.io/job-name=<job-name>-launcher-0 \
+  --tail=-1 -f
+```
+
+## Scaling
+
+Adjust `numNodes` and `resourcesPerNode` in `trainjob.yaml` to scale:
+
+| Nodes | GPUs per node | Total GPUs | Use case |
+|------:|:-------------:|-----------:|----------|
+| 2 | 2 | 4 | Default (multi-node verification) |
+| 2 | 4 | 8 | Higher per-node density |
+| 4 | 2 | 8 | More nodes, fewer GPUs each |
+
+## Benchmark parameters
+
+All parameters below are configurable in `trainjob.yaml`. Update them to match your benchmarking requirements.
+
+### Training parameters
+
+Set via `trainer.env` in `trainjob.yaml`. These are injected into all pod containers (launcher and workers) by the Kubeflow Trainer controller.
+
+| Variable | Default | Description | Impact of change |
+|----------|---------|-------------|-----------------|
+| `BENCH_MODEL` | `Qwen/Qwen2.5-1.5B-Instruct` | HuggingFace model ID | Larger model → more GPU memory, slower steps. Must stay under ~2.1B float32 params (MPI int32 limit) |
+| `BENCH_DATASET` | `openai/gsm8k` | HuggingFace dataset ID | Different dataset changes training content but not per-step performance |
+| `BENCH_DATASET_CONFIG` | `main` | Dataset configuration | Selects a subset/split of the dataset |
+| `BENCH_BATCH_SIZE` | `2` | Per-device batch size | Increase → higher GPU utilisation and throughput, more memory. Decrease → less memory, lower throughput |
+| `BENCH_MAX_SEQ_LENGTH` | `512` | Max token sequence length | Increase → more context per example, significantly more memory (attention is O(n²)), slower steps |
+| `BENCH_MAX_STEPS` | `200` | Training steps | Controls total benchmark duration. Does not affect per-step performance |
+| `BENCH_LEARNING_RATE` | `2e-5` | AdamW learning rate | Affects training quality (loss convergence), not throughput |
+| `BENCH_WARMUP_STEPS` | `5` | First N steps excluded from final timing averages | Increase for more accurate steady-state metrics. These steps still execute and log |
+| `BENCH_GRAD_ACCUM` | `1` | Gradient accumulation steps | Increase → simulates larger batch without extra memory, less frequent allreduce |
+| `BENCH_LOG_FREQ` | `1` | Log every N steps | Increase for less verbose output |
+
+### Infrastructure parameters
+
+Set in `trainer` and `podTemplateOverrides` sections of `trainjob.yaml`.
+
+| Parameter | Default | Description | Impact of change |
+|-----------|---------|-------------|-----------------|
+| `numNodes` | `2` | Number of nodes (each runs training + sshd) | More nodes → more GPUs, tests multi-node network scaling |
+| `nvidia.com/gpu` | `"2"` | GPUs per node (also sets MPI processes per node) | More GPUs per node → higher per-node density, more intra-node communication |
+| `memory` | `40Gi` | Memory per node | Increase for larger models or batch sizes |
+| `cpu` | `"8"` | CPU cores per node | Increase if data loading becomes a bottleneck |
+| `dshm sizeLimit` | `16Gi` | Shared memory (`/dev/shm`) for inter-GPU communication | Increase if you see `/dev/shm` out-of-memory errors |
+
+## Expected output
+
+The benchmark prints per-step metrics and a final summary:
+
+```
+============================================================
+BENCHMARK RESULTS (DDP + MPI)
+============================================================
+  Backend:            MPI (via DDP)
+  Model:              Qwen/Qwen2.5-1.5B-Instruct
+  Dtype:              float32
+  World size:         4 GPUs
+  Batch size/GPU:     2
+  Global batch:       8
+  Total steps:        200
+  Avg step time:      X.XXs (post-warmup)
+  Avg throughput:     X.XX samples/s
+  Peak GPU memory:    X.XGB
+============================================================
+```
+
+## Known issues
+
+### MPI backend dtype limitation on CUDA
+
+**Symptom:** `dist.all_reduce` on CUDA tensors fails with `IndexError: map::at` for `bfloat16` / `float16`.
+
+**Root cause:** OpenMPI's MPI datatype table does not include mappings for half-precision formats.
+
+**Workaround:** Load the model with `dtype=torch.float32`.
+
+### MPI int32 count limit (models > ~2B parameters)
+
+**Symptom:** `MPI_ERR_COUNT: invalid count argument` during DDP gradient allreduce on the first training step.
+
+**Root cause:** PyTorch DDP groups all gradients into a single flat buffer. For models with more than ~2.1 billion `float32` parameters, the element count exceeds MPI's `int32` count limit. This is why the benchmark uses the 1.5B model.
+
+## Cleanup
+
+```bash
+oc delete trainjobs -n kftv2-mpi-ddp-sft --all
+oc delete configmap mpi-ddp-sft-scripts -n kftv2-mpi-ddp-sft
+oc delete namespace kftv2-mpi-ddp-sft
+```

--- a/benchmarks/kftv2-mpi-ddp-sft-ddp/1.5b/mpi-runtime.yaml
+++ b/benchmarks/kftv2-mpi-ddp-sft-ddp/1.5b/mpi-runtime.yaml
@@ -1,0 +1,72 @@
+# ClusterTrainingRuntime for MPI + CUDA (OpenMPI with AIPCC)
+#
+# Deploy:
+#   oc apply -f mpi-runtime.yaml
+---
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: mpi-cuda-openmpi-benchmark
+  labels:
+    trainer.kubeflow.org/framework: openmpi
+spec:
+  mlPolicy:
+    mpi:
+      mpiImplementation: OpenMPI
+      numProcPerNode: 1
+      runLauncherAsNode: true
+      sshAuthMountPath: /home/mpiuser/.ssh
+    numNodes: 1
+  template:
+    spec:
+      network:
+        publishNotReadyAddresses: true
+      replicatedJobs:
+      - groupName: default
+        name: launcher
+        replicas: 1
+        template:
+          metadata:
+            labels:
+              trainer.kubeflow.org/trainjob-ancestor-step: trainer
+          spec:
+            template:
+              spec:
+                containers:
+                - image: quay.io/ksuta/odh-mpi-cuda:0.0.14
+                  name: node
+                  resources:
+                    limits:
+                      nvidia.com/gpu: "1"
+                    requests:
+                      nvidia.com/gpu: "1"
+      - groupName: default
+        name: node
+        replicas: 1
+        template:
+          spec:
+            template:
+              spec:
+                containers:
+                - args:
+                  - -De
+                  - -f
+                  - /home/mpiuser/.sshd_config
+                  command:
+                  - /usr/local/bin/uid_entrypoint.sh
+                  - /usr/sbin/sshd
+                  image: quay.io/ksuta/odh-mpi-cuda:0.0.14
+                  name: node
+                  readinessProbe:
+                    initialDelaySeconds: 3
+                    tcpSocket:
+                      port: 2222
+                  resources:
+                    limits:
+                      nvidia.com/gpu: "1"
+                    requests:
+                      nvidia.com/gpu: "1"
+      successPolicy:
+        operator: All
+        targetReplicatedJobs:
+        - launcher

--- a/benchmarks/kftv2-mpi-ddp-sft-ddp/1.5b/train_sft_ddp.py
+++ b/benchmarks/kftv2-mpi-ddp-sft-ddp/1.5b/train_sft_ddp.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+MPI DDP SFT Benchmark — Qwen 2.5 1.5B + GSM8K
+
+Distributed Supervised Fine-Tuning using PyTorch DistributedDataParallel (DDP)
+with MPI as the communications backend.
+
+Key constraints for MPI + DDP:
+  - Model must use float32 (MPI has no datatype mapping for bfloat16/float16)
+  - Model parameter count must be under ~2.1B (MPI int32 count limit)
+
+Launch via mpirun (handled by Kubeflow TrainJob MPI runtime):
+    mpirun python train_sft_ddp.py
+
+Environment variables:
+    BENCH_MODEL           HuggingFace model ID       (default: Qwen/Qwen2.5-1.5B-Instruct)
+    BENCH_DATASET         HuggingFace dataset ID     (default: openai/gsm8k)
+    BENCH_DATASET_CONFIG  Dataset configuration       (default: main)
+    BENCH_BATCH_SIZE      Per-device batch size       (default: 2)
+    BENCH_MAX_SEQ_LENGTH  Max token sequence length   (default: 512)
+    BENCH_MAX_STEPS       Training steps              (default: 200)
+    BENCH_LEARNING_RATE   AdamW learning rate         (default: 2e-5)
+    BENCH_WARMUP_STEPS    Steps excluded from timing  (default: 5)
+    BENCH_GRAD_ACCUM      Gradient accumulation steps (default: 1)
+    BENCH_LOG_FREQ        Log every N steps           (default: 1)
+"""
+
+import os
+import time
+
+import torch
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader, DistributedSampler
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from datasets import load_dataset
+
+# ---------------------------------------------------------------------------
+# Configuration from environment variables
+# ---------------------------------------------------------------------------
+MODEL_NAME = os.environ.get("BENCH_MODEL", "Qwen/Qwen2.5-1.5B-Instruct")
+DATASET_NAME = os.environ.get("BENCH_DATASET", "openai/gsm8k")
+DATASET_CONFIG = os.environ.get("BENCH_DATASET_CONFIG", "main")
+BATCH_SIZE = int(os.environ.get("BENCH_BATCH_SIZE", "2"))
+MAX_SEQ_LENGTH = int(os.environ.get("BENCH_MAX_SEQ_LENGTH", "512"))
+MAX_STEPS = int(os.environ.get("BENCH_MAX_STEPS", "200"))
+LEARNING_RATE = float(os.environ.get("BENCH_LEARNING_RATE", "2e-5"))
+LOG_FREQ = int(os.environ.get("BENCH_LOG_FREQ", "1"))
+WARMUP_STEPS = int(os.environ.get("BENCH_WARMUP_STEPS", "5"))
+GRADIENT_ACCUMULATION = int(os.environ.get("BENCH_GRAD_ACCUM", "1"))
+
+
+# ---------------------------------------------------------------------------
+# Distributed setup
+# ---------------------------------------------------------------------------
+def setup_distributed():
+    local_rank = int(os.environ.get("OMPI_COMM_WORLD_LOCAL_RANK", "0"))
+
+    if not dist.is_mpi_available():
+        raise RuntimeError(
+            "PyTorch was not built with MPI support. "
+            "Verify your image includes a torch build linked against MPI."
+        )
+
+    dist.init_process_group(backend="mpi")
+
+    torch.cuda.set_device(local_rank)
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    return rank, local_rank, world_size
+
+
+# ---------------------------------------------------------------------------
+# Dataset helpers
+# ---------------------------------------------------------------------------
+def format_sft_example(example, tokenizer, max_length):
+    """Tokenise a GSM8K example with prompt-masked labels for SFT loss."""
+    user_only = [{"role": "user", "content": example["question"]}]
+    prompt_text = tokenizer.apply_chat_template(
+        user_only, tokenize=False, add_generation_prompt=True
+    )
+    full_text = tokenizer.apply_chat_template(
+        [
+            {"role": "user", "content": example["question"]},
+            {"role": "assistant", "content": example["answer"]},
+        ],
+        tokenize=False,
+    )
+
+    encoding = tokenizer(
+        full_text,
+        truncation=True,
+        max_length=max_length,
+        padding="max_length",
+        return_tensors="pt",
+    )
+
+    prompt_ids = tokenizer(prompt_text, truncation=True, max_length=max_length)
+    prompt_len = len(prompt_ids["input_ids"])
+
+    labels = encoding["input_ids"].clone()
+    labels[0, :prompt_len] = -100
+    labels[labels == tokenizer.pad_token_id] = -100
+
+    return {
+        "input_ids": encoding["input_ids"].squeeze(0),
+        "attention_mask": encoding["attention_mask"].squeeze(0),
+        "labels": labels.squeeze(0),
+    }
+
+
+class SFTCollator:
+    """Batch collator that tokenises raw GSM8K rows on-the-fly."""
+
+    def __init__(self, tokenizer, max_length):
+        self.tokenizer = tokenizer
+        self.max_length = max_length
+
+    def __call__(self, batch):
+        formatted = [
+            format_sft_example(ex, self.tokenizer, self.max_length) for ex in batch
+        ]
+        return {
+            "input_ids": torch.stack([f["input_ids"] for f in formatted]),
+            "attention_mask": torch.stack([f["attention_mask"] for f in formatted]),
+            "labels": torch.stack([f["labels"] for f in formatted]),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    rank, local_rank, world_size = setup_distributed()
+    device = torch.device(f"cuda:{local_rank}")
+
+    if rank == 0:
+        print(f"{'=' * 60}", flush=True)
+        print("MPI DDP SFT Benchmark", flush=True)
+        print(f"{'=' * 60}", flush=True)
+        print(
+            f"world_size={world_size}, model={MODEL_NAME}, "
+            f"backend={dist.get_backend()}, dtype=float32",
+            flush=True,
+        )
+
+    # ---- Tokenizer & Model (rank 0 downloads first to avoid cache races) ----
+    if rank == 0:
+        tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+        _ = AutoModelForCausalLM.from_pretrained(MODEL_NAME, dtype=torch.float32)
+        del _
+        print("Rank 0: model downloaded and cached", flush=True)
+    dist.barrier()
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    model = AutoModelForCausalLM.from_pretrained(
+        MODEL_NAME,
+        dtype=torch.float32,
+    ).to(device)
+
+    param_count = sum(p.numel() for p in model.parameters())
+    if rank == 0:
+        print(f"Model loaded: {param_count / 1e9:.2f}B params (float32)", flush=True)
+
+    model = DDP(model, device_ids=[local_rank])
+
+    if rank == 0:
+        print("DDP wrapper applied successfully with MPI backend", flush=True)
+
+    # ---- Dataset ----
+    dataset = load_dataset(DATASET_NAME, DATASET_CONFIG, split="train")
+    if rank == 0:
+        print(f"Dataset: {len(dataset)} examples", flush=True)
+
+    sampler = DistributedSampler(
+        dataset, num_replicas=world_size, rank=rank, shuffle=True
+    )
+    dataloader = DataLoader(
+        dataset,
+        batch_size=BATCH_SIZE,
+        sampler=sampler,
+        collate_fn=SFTCollator(tokenizer, MAX_SEQ_LENGTH),
+        num_workers=2,
+        pin_memory=True,
+    )
+
+    # ---- Optimizer ----
+    optimizer = torch.optim.AdamW(model.parameters(), lr=LEARNING_RATE)
+
+    # ---- Metrics tracking ----
+    step_times = []
+    losses = []
+
+    if rank == 0:
+        print(
+            f"\nStarting training: max_steps={MAX_STEPS}, "
+            f"batch_size={BATCH_SIZE}, grad_accum={GRADIENT_ACCUMULATION}",
+            flush=True,
+        )
+
+    # ---- Training loop ----
+    global_step = 0
+    start_time = time.time()
+    model.train()
+    epoch = 0
+
+    while global_step < MAX_STEPS:
+        sampler.set_epoch(epoch)
+        for batch in dataloader:
+            if global_step >= MAX_STEPS:
+                break
+
+            step_start = time.time()
+
+            batch = {k: v.to(device) for k, v in batch.items()}
+            outputs = model(**batch)
+            loss = outputs.loss / GRADIENT_ACCUMULATION
+            loss.backward()
+
+            if (global_step + 1) % GRADIENT_ACCUMULATION == 0:
+                optimizer.step()
+                optimizer.zero_grad()
+
+            torch.cuda.synchronize()
+            step_time = time.time() - step_start
+            step_loss = loss.item() * GRADIENT_ACCUMULATION
+            step_times.append(step_time)
+            losses.append(step_loss)
+            global_step += 1
+
+            if rank == 0 and global_step % LOG_FREQ == 0:
+                gpu_alloc = torch.cuda.memory_allocated(local_rank) / 1e9
+                gpu_reserved = torch.cuda.memory_reserved(local_rank) / 1e9
+                print(
+                    f"[DDP-MPI] step={global_step} "
+                    f"step_time={step_time:.2f}s "
+                    f"loss={step_loss:.4f} "
+                    f"samples/s={BATCH_SIZE / step_time:.2f} "
+                    f"gpu_mem_alloc={gpu_alloc:.1f}GB "
+                    f"gpu_mem_reserved={gpu_reserved:.1f}GB",
+                    flush=True,
+                )
+
+        epoch += 1
+
+    total_time = time.time() - start_time
+
+    # ---- Summary ----
+    if rank == 0:
+        post_warmup = step_times[WARMUP_STEPS:] or step_times
+        avg_step = sum(post_warmup) / len(post_warmup)
+        min_step = min(post_warmup)
+        max_step = max(post_warmup)
+        throughput = BATCH_SIZE * world_size / avg_step
+        peak_mem = torch.cuda.max_memory_allocated() / 1e9
+        avg_loss = sum(losses[-len(post_warmup):]) / len(post_warmup)
+
+        print(f"\n{'=' * 60}", flush=True)
+        print("BENCHMARK RESULTS (DDP + MPI)", flush=True)
+        print(f"{'=' * 60}", flush=True)
+        print(f"  Backend:            MPI (via DDP)", flush=True)
+        print(f"  Model:              {MODEL_NAME}", flush=True)
+        print(f"  Dtype:              float32", flush=True)
+        print(f"  World size:         {world_size} GPUs", flush=True)
+        print(f"  Batch size/GPU:     {BATCH_SIZE}", flush=True)
+        print(f"  Global batch:       {BATCH_SIZE * world_size}", flush=True)
+        print(f"  Max seq length:     {MAX_SEQ_LENGTH}", flush=True)
+        print(f"  Grad accumulation:  {GRADIENT_ACCUMULATION}", flush=True)
+        print(f"  Total steps:        {global_step}", flush=True)
+        print(
+            f"  Total time:         {total_time:.1f}s ({total_time / 60:.1f} min)",
+            flush=True,
+        )
+        print(f"  Warmup steps:       {WARMUP_STEPS}", flush=True)
+        print(f"  Avg step time:      {avg_step:.2f}s (post-warmup)", flush=True)
+        print(f"  Min step time:      {min_step:.2f}s", flush=True)
+        print(f"  Max step time:      {max_step:.2f}s", flush=True)
+        print(f"  Avg throughput:     {throughput:.2f} samples/s", flush=True)
+        print(f"  Avg loss:           {avg_loss:.4f} (post-warmup)", flush=True)
+        print(f"  Peak GPU memory:    {peak_mem:.1f}GB", flush=True)
+        print(f"{'=' * 60}", flush=True)
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kftv2-mpi-ddp-sft-ddp/1.5b/trainjob.yaml
+++ b/benchmarks/kftv2-mpi-ddp-sft-ddp/1.5b/trainjob.yaml
@@ -1,0 +1,72 @@
+# MPI DDP SFT Benchmark — Qwen 2.5 1.5B + GSM8K
+#
+# Distributed SFT using PyTorch DDP with MPI as the communications backend.
+---
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  generateName: mpi-ddp-sft-
+  namespace: kftv2-mpi-ddp-sft
+spec:
+  runtimeRef:
+    apiGroup: trainer.kubeflow.org
+    kind: ClusterTrainingRuntime
+    name: mpi-cuda-openmpi-benchmark
+  trainer:
+    command:
+    - /usr/local/bin/uid_entrypoint.sh
+    - mpirun
+    - python
+    - /mnt/scripts/train_sft_ddp.py
+    numNodes: 2
+    resourcesPerNode:
+      limits:
+        nvidia.com/gpu: "2"
+        memory: 40Gi
+        cpu: "8"
+      requests:
+        nvidia.com/gpu: "2"
+        memory: 40Gi
+        cpu: "8"
+    env:
+    - name: BENCH_MODEL
+      value: "Qwen/Qwen2.5-1.5B-Instruct"
+    - name: BENCH_DATASET
+      value: "openai/gsm8k"
+    - name: BENCH_DATASET_CONFIG
+      value: "main"
+    - name: BENCH_MAX_STEPS
+      value: "200"
+    - name: BENCH_BATCH_SIZE
+      value: "2"
+    - name: BENCH_MAX_SEQ_LENGTH
+      value: "512"
+    - name: BENCH_LEARNING_RATE
+      value: "2e-5"
+    - name: BENCH_LOG_FREQ
+      value: "1"
+    - name: BENCH_WARMUP_STEPS
+      value: "5"
+    - name: BENCH_GRAD_ACCUM
+      value: "1"
+  podTemplateOverrides:
+  - targetJobs:
+    - name: launcher
+    - name: node
+    spec:
+      containers:
+      - name: node
+        volumeMounts:
+        - mountPath: /mnt/scripts
+          name: scripts
+          readOnly: true
+        - mountPath: /dev/shm
+          name: dshm
+      volumes:
+      - name: scripts
+        configMap:
+          name: mpi-ddp-sft-scripts
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 16Gi


### PR DESCRIPTION
Add MPI benchmark with SFT+DDP
Resolves [RHOAIENG-51103](https://redhat.atlassian.net/browse/RHOAIENG-51103)

## Description
- Adds a distributed SFT benchmark using **PyTorch DDP with MPI** as the communications backend
- Model: Qwen 2.5 1.5B-Instruct fine-tuned on GSM8K dataset

## How Has This Been Tested?
- Deployed TrainJob on OpenShift cluster (2 nodes x 2 GPUs)
- DDP wrapper applied successfully with MPI backend
- 200 training steps completed without errors
- Gradient synchronization verified via MPI allreduce across all 4 GPUs
- Consistent step times (~3% variance) confirming stable MPI communication

## Benchmark Results (200 steps)
```
| Metric | Value |
| Total time | 25.3 min |
| Avg step time | 7.52s (post-warmup) |
| Min / Max step time | 7.40s / 7.63s |
| Avg throughput | 1.06 samples/s |
| Peak GPU memory | 37.8 GB |
| Avg loss (post-warmup)| 0.4135 |
```

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runnable MPI+CUDA multi-node supervised fine-tuning benchmark for Qwen 2.5 1.5B using DDP: includes a distributed training script, a cluster runtime manifest, and a job manifest to launch multi-node runs.

* **Documentation**
  * Added a comprehensive README with deployment steps, configurable benchmark and infra parameters (env vars), expected result format, known MPI/CUDA limitations with workarounds, runtime/image details, and cleanup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->