### PR TITLE
fix: rename openmpi tekton files from torch29 to torch210

### DIFF
--- a/.tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-pull-request.yaml
+++ b/.tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-pull-request.yaml
@@ -5,19 +5,21 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
+      event == "pull_request"
       && target_branch == "main"
       && ( "images/runtime/training/py312-cuda130-torch29-openmpi41/**".pathChanged()
-            || ".tekton/odh-training-cuda130-torch29-py312-openmpi41-ci-on-push.yaml".pathChanged() )
+            || ".tekton/odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
-    appstudio.openshift.io/component: odh-training-cuda130-torch29-py312-openmpi41-ci
+    appstudio.openshift.io/component: odh-training-cuda130-torch210-py312-openmpi41-ci
     pipelines.appstudio.openshift.io/type: build
-  name: odh-training-cuda130-torch29-py312-openmpi41-ci-on-push
+  name: odh-training-cuda130-torch210-py312-openmpi41-ci-on-pull-request
   namespace: open-data-hub-tenant
 spec:
   params:
@@ -26,11 +28,16 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-training-cuda130-torch29-py312-openmpi41:odh-stable
+    value: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-pr
   - name: dockerfile
     value: Dockerfile
   - name: path-context
-    value: images/runtime/training/py312-cuda130-torch29-openmpi41
+    value: images/runtime/training/py312-cuda130-torch210-openmpi41
+  - name: pipeline-type
+    value: pull-request
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
   pipelineRef:
     resolver: git
     params:
@@ -41,7 +48,7 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-training-cuda130-torch29-py312-openmpi41-ci
+    serviceAccountName: build-pipeline-odh-training-cuda130-torch210-py312-openmpi41-ci
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-push.yaml
+++ b/.tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-push.yaml
@@ -5,21 +5,19 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request"
+      event == "push"
       && target_branch == "main"
-      && ( "images/runtime/training/py312-cuda130-torch29-openmpi41/**".pathChanged()
-            || ".tekton/odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request.yaml".pathChanged() )
+      && ( "images/runtime/training/py312-cuda130-torch210-openmpi41/**".pathChanged()
+            || ".tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
-    appstudio.openshift.io/component: odh-training-cuda130-torch29-py312-openmpi41-ci
+    appstudio.openshift.io/component: odh-training-cuda130-torch210-py312-openmpi41-ci
     pipelines.appstudio.openshift.io/type: build
-  name: odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request
+  name: odh-training-cuda130-torch210-py312-openmpi41-ci-on-push
   namespace: open-data-hub-tenant
 spec:
   params:
@@ -28,16 +26,11 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-training-cuda130-torch29-py312-openmpi41:odh-pr
+    value: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-stable
   - name: dockerfile
     value: Dockerfile
   - name: path-context
-    value: images/runtime/training/py312-cuda130-torch29-openmpi41
-  - name: pipeline-type
-    value: pull-request
-  - name: additional-tags
-    value:
-    - 'odh-pr-{{revision}}'
+    value: images/runtime/training/py312-cuda130-torch210-openmpi41
   pipelineRef:
     resolver: git
     params:
@@ -48,7 +41,7 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-training-cuda130-torch29-py312-openmpi41-ci
+    serviceAccountName: build-pipeline-odh-training-cuda130-torch210-py312-openmpi41-ci
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Renames the Konflux .tekton pipeline files for the OpenMPI CUDA image from torch29 to torch210 to match the image directory rename introduced in PR #782. Removes the old torch29 files and adds new torch210 files pointing to images/runtime/training/py312-cuda130-torch210-openmpi41.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configurations to target the PyTorch 2.1.0 variant of the training runtime container image, replacing the PyTorch 2.9 variant. Changes include build trigger configurations, container image references, and related build parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->