### PR TITLE
Add E2E test for multi-node OpenMPI TrainJob execution

### DIFF
--- a/tests/trainer/cluster_training_runtimes_test.go
+++ b/tests/trainer/cluster_training_runtimes_test.go
@@ -83,10 +83,18 @@ func TestDefaultClusterTrainingRuntimes(t *testing.T) {
 		test.Expect(foundImage).NotTo(BeEmpty(), "No container image found in ClusterTrainingRuntime %s", runtime.Name)
 		test.T().Logf("Image referred in ClusterTrainingRuntime is %s", foundImage)
 
-		expectedImage := imagePrefix + "/" + expectedRuntime.Image
-		test.Expect(foundImage).To(ContainSubstring(expectedImage),
-			"Image %s should contain %s", foundImage, expectedImage)
-		test.T().Logf("ClusterTrainingRuntime '%s' uses expected image: %s", expectedRuntime.Name, expectedImage)
+		if trainerutils.IsMPIRuntime(runtime.Name) {
+			test.Expect(foundImage).To(HavePrefix("quay.io/"),
+				"MPI image %s should originate from quay.io", foundImage)
+			test.Expect(foundImage).To(ContainSubstring(expectedRuntime.Image),
+				"MPI image %s should contain %s", foundImage, expectedRuntime.Image)
+			test.T().Logf("MPI ClusterTrainingRuntime '%s' uses expected image: %s", expectedRuntime.Name, foundImage)
+		} else {
+			expectedImage := imagePrefix + "/" + expectedRuntime.Image
+			test.Expect(foundImage).To(ContainSubstring(expectedImage),
+				"Image %s should contain %s", foundImage, expectedImage)
+			test.T().Logf("ClusterTrainingRuntime '%s' uses expected image: %s", expectedRuntime.Name, expectedImage)
+		}
 	}
 
 	// Verify all expected runtimes are present
@@ -172,8 +180,8 @@ func TestRunTrainJobWithDefaultClusterTrainingRuntimes(t *testing.T) {
 	// Run one TrainJob per unique image to avoid redundant runs for CTRs that share the same image
 	tested := make(map[string]bool)
 	for _, runtime := range trainerutils.ExpectedRuntimes {
-		if runtime.Name == trainerutils.DefaultClusterTrainingRuntimeOpenMPICUDA {
-			test.T().Logf("Skipping ClusterTrainingRuntime '%s' in generic runtime execution test; OpenMPI has dedicated coverage", runtime.Name)
+		if trainerutils.IsMPIRuntime(runtime.Name) {
+			test.T().Logf("Skipping MPI runtime '%s' (covered by TestMultiNodeOpenMPITrainJob)", runtime.Name)
 			continue
 		}
 		if tested[runtime.Image] {

--- a/tests/trainer/resources/fashion_mnist_mpi.py
+++ b/tests/trainer/resources/fashion_mnist_mpi.py
@@ -1,0 +1,113 @@
+import os
+import socket
+import logging
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.utils.data import DataLoader, Subset
+
+
+def train_mpi_fashion_mnist():
+    rank = int(os.environ.get("OMPI_COMM_WORLD_RANK", "-1"))
+    size = int(os.environ.get("OMPI_COMM_WORLD_SIZE", "-1"))
+    local_rank = int(os.environ.get("OMPI_COMM_WORLD_LOCAL_RANK", "0"))
+    expected_size = int(os.environ.get("EXPECTED_WORLD_SIZE", "2"))
+    hostname = socket.gethostname()
+
+    assert rank >= 0, "OMPI_COMM_WORLD_RANK not set"
+    assert size == expected_size, f"Expected {expected_size} MPI processes, got {size}"
+
+    formatter = logging.Formatter("%(asctime)s %(levelname)-8s %(message)s")
+    logger = logging.getLogger("fashion_mnist_mpi")
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    use_cuda = torch.cuda.is_available()
+    device = torch.device(f"cuda:{local_rank}" if use_cuda else "cpu")
+
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv1 = nn.Conv2d(1, 32, 3, 1)
+            self.conv2 = nn.Conv2d(32, 64, 3, 1)
+            self.fc1 = nn.Linear(9216, 128)
+            self.fc2 = nn.Linear(128, 10)
+
+        def forward(self, x):
+            x = F.relu(self.conv1(x))
+            x = F.relu(self.conv2(x))
+            x = F.max_pool2d(x, 2)
+            x = x.view(-1, 9216)
+            x = F.relu(self.fc1(x))
+            x = self.fc2(x)
+            return F.log_softmax(x, dim=1)
+
+    model = Net().to(device)
+    model.train()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
+
+    dataset_path = os.environ.get("DATASET_PATH", "/tmp/fashion-mnist")
+    max_samples = int(os.environ.get("MAX_SAMPLES", "2048"))
+    batch_size = int(os.environ.get("BATCH_SIZE", "64"))
+    num_epochs = int(os.environ.get("NUM_EPOCHS", "1"))
+
+    from torchvision import datasets, transforms
+
+    try:
+        dataset = datasets.FashionMNIST(
+            dataset_path,
+            train=True,
+            download=False,
+            transform=transforms.Compose([transforms.ToTensor()]),
+        )
+        logger.info("[Rank %s/%s] Using local FashionMNIST dataset at %s", rank, size, dataset_path)
+    except Exception as err:
+        logger.warning(
+            "[Rank %s/%s] Local FashionMNIST missing (%s). Downloading dataset.",
+            rank, size, err
+        )
+        dataset = datasets.FashionMNIST(
+            dataset_path,
+            train=True,
+            download=True,
+            transform=transforms.Compose([transforms.ToTensor()]),
+        )
+        logger.info("[Rank %s/%s] Downloaded FashionMNIST dataset to %s", rank, size, dataset_path)
+
+    total_samples = min(len(dataset), max_samples)
+    indices = list(range(rank, total_samples, size))
+    rank_dataset = Subset(dataset, indices)
+    train_loader = DataLoader(rank_dataset, batch_size=batch_size, shuffle=True)
+
+    logger.info("[Rank %s/%s] Running on %s", rank, size, hostname)
+    logger.info(
+        "[Rank %s/%s] PyTorch %s, CUDA available: %s", rank, size, torch.__version__, use_cuda
+    )
+
+    for epoch in range(num_epochs):
+        epoch_loss = 0.0
+        steps = 0
+        for batch_x, batch_y in train_loader:
+            batch_x = batch_x.to(device)
+            batch_y = batch_y.to(device)
+
+            outputs = model(batch_x)
+            loss = F.nll_loss(outputs, batch_y)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            epoch_loss += loss.item()
+            steps += 1
+
+        avg_loss = epoch_loss / steps if steps > 0 else 0.0
+        logger.info("[Rank %s/%s] Epoch %s avg_loss=%.6f", rank, size, epoch, avg_loss)
+
+    logger.info("[Rank %s/%s] MPI TrainJob test PASSED", rank, size)
+
+
+if __name__ == "__main__":
+    train_mpi_fashion_mnist()

--- a/tests/trainer/resources/fashion_mnist_mpi.py
+++ b/tests/trainer/resources/fashion_mnist_mpi.py
@@ -10,12 +10,9 @@ from torch.utils.data import DataLoader, Subset
 
 
 def train_mpi_fashion_mnist():
-    rank = int(os.environ.get("OMPI_COMM_WORLD_RANK", "-1"))
     local_rank = int(os.environ.get("OMPI_COMM_WORLD_LOCAL_RANK", "0"))
     expected_size = 2
     hostname = socket.gethostname()
-
-    assert rank >= 0, "OMPI_COMM_WORLD_RANK not set"
 
     # Explicitly initialize PyTorch distributed with MPI backend for this E2E.
     dist.init_process_group(backend="mpi")

--- a/tests/trainer/resources/fashion_mnist_mpi.py
+++ b/tests/trainer/resources/fashion_mnist_mpi.py
@@ -3,6 +3,7 @@ import socket
 import logging
 
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F
 from torch import nn
 from torch.utils.data import DataLoader, Subset
@@ -10,12 +11,16 @@ from torch.utils.data import DataLoader, Subset
 
 def train_mpi_fashion_mnist():
     rank = int(os.environ.get("OMPI_COMM_WORLD_RANK", "-1"))
-    size = int(os.environ.get("OMPI_COMM_WORLD_SIZE", "-1"))
     local_rank = int(os.environ.get("OMPI_COMM_WORLD_LOCAL_RANK", "0"))
-    expected_size = int(os.environ.get("EXPECTED_WORLD_SIZE", "2"))
+    expected_size = 2
     hostname = socket.gethostname()
 
     assert rank >= 0, "OMPI_COMM_WORLD_RANK not set"
+
+    # Explicitly initialize PyTorch distributed with MPI backend for this E2E.
+    dist.init_process_group(backend="mpi")
+    rank = dist.get_rank()
+    size = dist.get_world_size()
     assert size == expected_size, f"Expected {expected_size} MPI processes, got {size}"
 
     formatter = logging.Formatter("%(asctime)s %(levelname)-8s %(message)s")
@@ -107,6 +112,7 @@ def train_mpi_fashion_mnist():
         logger.info("[Rank %s/%s] Epoch %s avg_loss=%.6f", rank, size, epoch, avg_loss)
 
     logger.info("[Rank %s/%s] MPI TrainJob test PASSED", rank, size)
+    dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/tests/trainer/trainer_mpi_test.go
+++ b/tests/trainer/trainer_mpi_test.go
@@ -60,9 +60,6 @@ func TestMultiNodeOpenMPITrainJob(t *testing.T) {
 		LabelSelector: "jobset.sigs.k8s.io/jobset-name=" + trainJob.Name + ",jobset.sigs.k8s.io/replicatedjob-name=launcher",
 	})
 	test.Expect(launcherPods).To(HaveLen(1), "Expected exactly 1 launcher pod")
-	if len(launcherPods) != 1 {
-		test.T().Fatalf("Expected exactly 1 launcher pod, got %d", len(launcherPods))
-	}
 
 	logs := GetPodLog(test, namespace, launcherPods[0].Name, corev1.PodLogOptions{})
 	test.Expect(logs).To(ContainSubstring("MPI TrainJob test PASSED"),

--- a/tests/trainer/trainer_mpi_test.go
+++ b/tests/trainer/trainer_mpi_test.go
@@ -57,12 +57,17 @@ func TestMultiNodeOpenMPITrainJob(t *testing.T) {
 		LabelSelector: "jobset.sigs.k8s.io/jobset-name=" + trainJob.Name + ",jobset.sigs.k8s.io/replicatedjob-name=launcher",
 	})
 	test.Expect(launcherPods).To(HaveLen(1), "Expected exactly 1 launcher pod")
+	if len(launcherPods) == 0 {
+		test.T().FailNow()
+	}
 
 	logs := GetPodLog(test, namespace, launcherPods[0].Name, corev1.PodLogOptions{})
 	test.Expect(logs).To(ContainSubstring("MPI TrainJob test PASSED"),
 		"Launcher logs should contain MPI success marker")
 	test.Expect(logs).To(ContainSubstring("[Rank 0/2]"),
 		"Launcher logs should show rank 0 of 2 processes")
+	test.Expect(logs).To(ContainSubstring("[Rank 1/2]"),
+		"Launcher logs should show rank 1 of 2 processes")
 	test.T().Logf("Launcher pod logs:\n%s", logs)
 }
 

--- a/tests/trainer/trainer_mpi_test.go
+++ b/tests/trainer/trainer_mpi_test.go
@@ -60,6 +60,9 @@ func TestMultiNodeOpenMPITrainJob(t *testing.T) {
 		LabelSelector: "jobset.sigs.k8s.io/jobset-name=" + trainJob.Name + ",jobset.sigs.k8s.io/replicatedjob-name=launcher",
 	})
 	test.Expect(launcherPods).To(HaveLen(1), "Expected exactly 1 launcher pod")
+	if len(launcherPods) != 1 {
+		test.T().Fatalf("Expected exactly 1 launcher pod, got %d", len(launcherPods))
+	}
 
 	logs := GetPodLog(test, namespace, launcherPods[0].Name, corev1.PodLogOptions{})
 	test.Expect(logs).To(ContainSubstring("MPI TrainJob test PASSED"),

--- a/tests/trainer/trainer_mpi_test.go
+++ b/tests/trainer/trainer_mpi_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package trainer
 
 import (
-	"encoding/base64"
 	"testing"
 
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -38,8 +37,10 @@ func TestMultiNodeOpenMPITrainJob(t *testing.T) {
 
 	namespace := test.NewTestNamespace().Name
 
-	mpiTrainingScript := string(readFile(test, "resources/fashion_mnist_mpi.py"))
-	trainJob := createMPITrainJob(test, namespace, mpiTrainingScript)
+	mpiScriptConfigMap := CreateConfigMap(test, namespace, map[string][]byte{
+		"fashion_mnist_mpi.py": readFile(test, "resources/fashion_mnist_mpi.py"),
+	})
+	trainJob := createMPITrainJob(test, namespace, mpiScriptConfigMap.Name)
 
 	test.Eventually(TrainJob(test, namespace, trainJob.Name), TestTimeoutDouble).
 		Should(Satisfy(TrainJobReachedFinalState))
@@ -70,10 +71,8 @@ func TestMultiNodeOpenMPITrainJob(t *testing.T) {
 	test.T().Logf("Launcher pod logs:\n%s", logs)
 }
 
-func createMPITrainJob(test Test, namespace, trainingScript string) *trainerv1alpha1.TrainJob {
+func createMPITrainJob(test Test, namespace, scriptConfigMapName string) *trainerv1alpha1.TrainJob {
 	test.T().Helper()
-
-	encodedScript := base64.StdEncoding.EncodeToString([]byte(trainingScript))
 
 	trainJob := &trainerv1alpha1.TrainJob{
 		ObjectMeta: metav1.ObjectMeta{
@@ -88,8 +87,7 @@ func createMPITrainJob(test Test, namespace, trainingScript string) *trainerv1al
 				NumNodes: Ptr(int32(2)),
 				Command: []string{
 					"mpirun",
-					"python", "-c",
-					`import base64; exec(base64.b64decode("` + encodedScript + `").decode("utf-8"))`,
+					"python", "/etc/mpi-test/fashion_mnist_mpi.py",
 				},
 				ResourcesPerNode: &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -97,6 +95,39 @@ func createMPITrainJob(test Test, namespace, trainingScript string) *trainerv1al
 					},
 					Limits: corev1.ResourceList{
 						corev1.ResourceName(NVIDIA.ResourceLabel): resource.MustParse("1"),
+					},
+				},
+			},
+			PodTemplateOverrides: []trainerv1alpha1.PodTemplateOverride{
+				{
+					TargetJobs: []trainerv1alpha1.PodTemplateOverrideTargetJob{
+						{Name: "launcher"},
+						{Name: "node"},
+					},
+					Spec: &trainerv1alpha1.PodTemplateSpecOverride{
+						Containers: []trainerv1alpha1.ContainerOverride{
+							{
+								Name: "node",
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "mpi-test-script",
+										MountPath: "/etc/mpi-test",
+									},
+								},
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "mpi-test-script",
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: scriptConfigMapName,
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/tests/trainer/trainer_mpi_test.go
+++ b/tests/trainer/trainer_mpi_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestMultiNodeOpenMPITrainJob(t *testing.T) {
-	Tags(t, Sanity, MultiNodeGpu(2, NVIDIA))
+	Tags(t, KftoCuda, MultiNodeGpu(2, NVIDIA))
 	test := With(t)
 
 	namespace := test.NewTestNamespace().Name
@@ -56,9 +56,8 @@ func TestMultiNodeOpenMPITrainJob(t *testing.T) {
 	launcherPods := GetPods(test, namespace, metav1.ListOptions{
 		LabelSelector: "jobset.sigs.k8s.io/jobset-name=" + trainJob.Name + ",jobset.sigs.k8s.io/replicatedjob-name=launcher",
 	})
-	test.Expect(launcherPods).To(HaveLen(1), "Expected exactly 1 launcher pod")
-	if len(launcherPods) == 0 {
-		test.T().FailNow()
+	if len(launcherPods) != 1 {
+		test.T().Fatalf("Expected exactly 1 launcher pod, got %d", len(launcherPods))
 	}
 
 	logs := GetPodLog(test, namespace, launcherPods[0].Name, corev1.PodLogOptions{})
@@ -100,10 +99,10 @@ print(f"[Rank {rank}/{size}] MPI TrainJob test PASSED")`,
 				},
 				ResourcesPerNode: &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						"nvidia.com/gpu": resource.MustParse("1"),
+						corev1.ResourceName(NVIDIA.ResourceLabel): resource.MustParse("1"),
 					},
 					Limits: corev1.ResourceList{
-						"nvidia.com/gpu": resource.MustParse("1"),
+						corev1.ResourceName(NVIDIA.ResourceLabel): resource.MustParse("1"),
 					},
 				},
 			},

--- a/tests/trainer/trainer_mpi_test.go
+++ b/tests/trainer/trainer_mpi_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package trainer
 
 import (
+	"encoding/base64"
 	"testing"
 
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -37,7 +38,8 @@ func TestMultiNodeOpenMPITrainJob(t *testing.T) {
 
 	namespace := test.NewTestNamespace().Name
 
-	trainJob := createMPITrainJob(test, namespace)
+	mpiTrainingScript := string(readFile(test, "resources/fashion_mnist_mpi.py"))
+	trainJob := createMPITrainJob(test, namespace, mpiTrainingScript)
 
 	test.Eventually(TrainJob(test, namespace, trainJob.Name), TestTimeoutDouble).
 		Should(Satisfy(TrainJobReachedFinalState))
@@ -56,9 +58,7 @@ func TestMultiNodeOpenMPITrainJob(t *testing.T) {
 	launcherPods := GetPods(test, namespace, metav1.ListOptions{
 		LabelSelector: "jobset.sigs.k8s.io/jobset-name=" + trainJob.Name + ",jobset.sigs.k8s.io/replicatedjob-name=launcher",
 	})
-	if len(launcherPods) != 1 {
-		test.T().Fatalf("Expected exactly 1 launcher pod, got %d", len(launcherPods))
-	}
+	test.Expect(launcherPods).To(HaveLen(1), "Expected exactly 1 launcher pod")
 
 	logs := GetPodLog(test, namespace, launcherPods[0].Name, corev1.PodLogOptions{})
 	test.Expect(logs).To(ContainSubstring("MPI TrainJob test PASSED"),
@@ -70,8 +70,10 @@ func TestMultiNodeOpenMPITrainJob(t *testing.T) {
 	test.T().Logf("Launcher pod logs:\n%s", logs)
 }
 
-func createMPITrainJob(test Test, namespace string) *trainerv1alpha1.TrainJob {
+func createMPITrainJob(test Test, namespace, trainingScript string) *trainerv1alpha1.TrainJob {
 	test.T().Helper()
+
+	encodedScript := base64.StdEncoding.EncodeToString([]byte(trainingScript))
 
 	trainJob := &trainerv1alpha1.TrainJob{
 		ObjectMeta: metav1.ObjectMeta{
@@ -87,15 +89,7 @@ func createMPITrainJob(test Test, namespace string) *trainerv1alpha1.TrainJob {
 				Command: []string{
 					"mpirun",
 					"python", "-c",
-					`import os, socket, torch
-rank = int(os.environ.get("OMPI_COMM_WORLD_RANK", "-1"))
-size = int(os.environ.get("OMPI_COMM_WORLD_SIZE", "-1"))
-hostname = socket.gethostname()
-print(f"[Rank {rank}/{size}] Running on {hostname}")
-assert size == 2, f"Expected 2 MPI processes, got {size}"
-assert rank >= 0, f"OMPI_COMM_WORLD_RANK not set"
-print(f"[Rank {rank}/{size}] PyTorch {torch.__version__}, CUDA available: {torch.cuda.is_available()}")
-print(f"[Rank {rank}/{size}] MPI TrainJob test PASSED")`,
+					`import base64; exec(base64.b64decode("` + encodedScript + `").decode("utf-8"))`,
 				},
 				ResourcesPerNode: &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{

--- a/tests/trainer/trainer_mpi_test.go
+++ b/tests/trainer/trainer_mpi_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trainer
+
+import (
+	"testing"
+
+	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/opendatahub-io/distributed-workloads/tests/common"
+	. "github.com/opendatahub-io/distributed-workloads/tests/common/support"
+	trainerutils "github.com/opendatahub-io/distributed-workloads/tests/trainer/utils"
+)
+
+func TestMultiNodeOpenMPITrainJob(t *testing.T) {
+	Tags(t, Sanity, MultiNodeGpu(2, NVIDIA))
+	test := With(t)
+
+	namespace := test.NewTestNamespace().Name
+
+	trainJob := createMPITrainJob(test, namespace)
+
+	test.Eventually(TrainJob(test, namespace, trainJob.Name), TestTimeoutDouble).
+		Should(Satisfy(TrainJobReachedFinalState))
+
+	finalJob := TrainJob(test, namespace, trainJob.Name)(test)
+	test.Expect(finalJob).To(WithTransform(TrainJobConditionComplete, Equal(metav1.ConditionTrue)),
+		"TrainJob %s/%s should be complete; TrainJobFailed message: %s",
+		namespace, trainJob.Name, TrainJobFailedMessage(finalJob))
+
+	test.T().Logf("MPI TrainJob %s/%s completed successfully", namespace, trainJob.Name)
+
+	jobset := SingleJobSet(test, namespace)(test)
+	test.Expect(jobset).To(WithTransform(JobSetReplicatedJobsCount, Equal(2)),
+		"MPI JobSet should have exactly 2 replicatedJobs (launcher + node)")
+
+	launcherPods := GetPods(test, namespace, metav1.ListOptions{
+		LabelSelector: "jobset.sigs.k8s.io/jobset-name=" + trainJob.Name + ",jobset.sigs.k8s.io/replicatedjob-name=launcher",
+	})
+	test.Expect(launcherPods).To(HaveLen(1), "Expected exactly 1 launcher pod")
+
+	logs := GetPodLog(test, namespace, launcherPods[0].Name, corev1.PodLogOptions{})
+	test.Expect(logs).To(ContainSubstring("MPI TrainJob test PASSED"),
+		"Launcher logs should contain MPI success marker")
+	test.Expect(logs).To(ContainSubstring("[Rank 0/2]"),
+		"Launcher logs should show rank 0 of 2 processes")
+	test.T().Logf("Launcher pod logs:\n%s", logs)
+}
+
+func createMPITrainJob(test Test, namespace string) *trainerv1alpha1.TrainJob {
+	test.T().Helper()
+
+	trainJob := &trainerv1alpha1.TrainJob{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-mpi-trainjob-",
+			Namespace:    namespace,
+		},
+		Spec: trainerv1alpha1.TrainJobSpec{
+			RuntimeRef: trainerv1alpha1.RuntimeRef{
+				Name: trainerutils.DefaultClusterTrainingRuntimeOpenMPICUDA,
+			},
+			Trainer: &trainerv1alpha1.Trainer{
+				NumNodes: Ptr(int32(2)),
+				Command: []string{
+					"mpirun",
+					"python", "-c",
+					`import os, socket, torch
+rank = int(os.environ.get("OMPI_COMM_WORLD_RANK", "-1"))
+size = int(os.environ.get("OMPI_COMM_WORLD_SIZE", "-1"))
+hostname = socket.gethostname()
+print(f"[Rank {rank}/{size}] Running on {hostname}")
+assert size == 2, f"Expected 2 MPI processes, got {size}"
+assert rank >= 0, f"OMPI_COMM_WORLD_RANK not set"
+print(f"[Rank {rank}/{size}] PyTorch {torch.__version__}, CUDA available: {torch.cuda.is_available()}")
+print(f"[Rank {rank}/{size}] MPI TrainJob test PASSED")`,
+				},
+				ResourcesPerNode: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"nvidia.com/gpu": resource.MustParse("1"),
+					},
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu": resource.MustParse("1"),
+					},
+				},
+			},
+		},
+	}
+
+	created, err := test.Client().Trainer().TrainerV1alpha1().TrainJobs(namespace).Create(
+		test.Ctx(),
+		trainJob,
+		metav1.CreateOptions{},
+	)
+	test.Expect(err).NotTo(HaveOccurred(), "Failed to create MPI TrainJob")
+	test.T().Logf("Created MPI TrainJob %s/%s successfully", created.Namespace, created.Name)
+
+	return created
+}

--- a/tests/trainer/utils/utils_runtimes.go
+++ b/tests/trainer/utils/utils_runtimes.go
@@ -55,9 +55,6 @@ const (
 
 	// DefaultClusterTrainingRuntimeCPU is the default runtime for CPU-only torch-distributed workloads
 	DefaultClusterTrainingRuntimeCPU = "torch-distributed-cpu"
-
-	// DefaultClusterTrainingRuntimeOpenMPICUDA is the default runtime for OpenMPI CUDA workloads
-	DefaultClusterTrainingRuntimeOpenMPICUDA = "openmpi-cuda"
 )
 
 var DefaultClusterTrainingRuntimes = []string{
@@ -68,7 +65,6 @@ var DefaultClusterTrainingRuntimes = []string{
 	DefaultTrainingHubRuntimeCUDA,
 	DefaultTrainingHubRuntimeCPU,
 	DefaultTrainingHubRuntimeROCm,
-	DefaultClusterTrainingRuntimeOpenMPICUDA,
 }
 
 var mpiRuntimes = map[string]bool{
@@ -123,7 +119,6 @@ var ExpectedRuntimes = []ClusterTrainingRuntime{
 	{Name: "training-hub-th06-cuda130-torch291-py312", Image: "odh-th06-cuda130-torch291-py312"},
 	{Name: "training-hub-th06-cpu-torch291-py312", Image: "odh-th06-cpu-torch291-py312"},
 	{Name: "training-hub-th06-rocm64-torch291-py312", Image: "odh-th06-rocm64-torch291-py312"},
-	{Name: DefaultClusterTrainingRuntimeOpenMPICUDA, Image: "odh-training-cuda130-torch210-py312-openmpi41"},
 }
 
 // GetImageFromClusterTrainingRuntime retrieves the container image from the named ClusterTrainingRuntime

--- a/tests/trainer/utils/utils_runtimes.go
+++ b/tests/trainer/utils/utils_runtimes.go
@@ -55,6 +55,9 @@ const (
 
 	// DefaultClusterTrainingRuntimeCPU is the default runtime for CPU-only torch-distributed workloads
 	DefaultClusterTrainingRuntimeCPU = "torch-distributed-cpu"
+
+	// DefaultClusterTrainingRuntimeOpenMPICUDA is the default runtime for OpenMPI CUDA workloads
+	DefaultClusterTrainingRuntimeOpenMPICUDA = "openmpi-cuda"
 )
 
 var DefaultClusterTrainingRuntimes = []string{
@@ -65,6 +68,15 @@ var DefaultClusterTrainingRuntimes = []string{
 	DefaultTrainingHubRuntimeCUDA,
 	DefaultTrainingHubRuntimeCPU,
 	DefaultTrainingHubRuntimeROCm,
+	DefaultClusterTrainingRuntimeOpenMPICUDA,
+}
+
+var mpiRuntimes = map[string]bool{
+	DefaultClusterTrainingRuntimeOpenMPICUDA: true,
+}
+
+func IsMPIRuntime(name string) bool {
+	return mpiRuntimes[name]
 }
 
 func IsDefaultRuntime(name string) bool {
@@ -111,6 +123,7 @@ var ExpectedRuntimes = []ClusterTrainingRuntime{
 	{Name: "training-hub-th06-cuda130-torch291-py312", Image: "odh-th06-cuda130-torch291-py312"},
 	{Name: "training-hub-th06-cpu-torch291-py312", Image: "odh-th06-cpu-torch291-py312"},
 	{Name: "training-hub-th06-rocm64-torch291-py312", Image: "odh-th06-rocm64-torch291-py312"},
+	{Name: DefaultClusterTrainingRuntimeOpenMPICUDA, Image: "odh-training-cuda130-torch210-py312-openmpi41"},
 }
 
 // GetImageFromClusterTrainingRuntime retrieves the container image from the named ClusterTrainingRuntime


### PR DESCRIPTION
```markdown
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add E2E test coverage for multi-node, multi-process OpenMPI TrainJob execution on OpenShift via KFTv2 (RHOAIENG-58883).

**Changes:**

- `tests/trainer/trainer_mpi_test.go` (new): `TestMultiNodeOpenMPITrainJob` creates a 2-node, 1-GPU-per-node TrainJob using the `openmpi-cuda` ClusterTrainingRuntime, runs `mpirun python -c "..."` to verify MPI rank coordination (`OMPI_COMM_WORLD_RANK`, `OMPI_COMM_WORLD_SIZE`), and asserts job completion, JobSet structure (launcher + node), and launcher log output.
- `tests/trainer/utils/utils_runtimes.go`: Registers `openmpi-cuda` as a known runtime (`DefaultClusterTrainingRuntimeOpenMPICUDA` constant, `ExpectedRuntimes` entry, `IsMPIRuntime()` helper).
- `tests/trainer/cluster_training_runtimes_test.go`: `TestDefaultClusterTrainingRuntimes` now validates MPI runtime images without requiring `registry.redhat.io` prefix (MPI images use `quay.io`). `TestRunTrainJobWithDefaultClusterTrainingRuntimes` delegates MPI runtimes to the dedicated MPI test since they require multi-node GPU setup with `mpirun`.

## How Has This Been Tested?

**Cluster:** OpenShift 4.19.24, RHOAI 3.3.0, 3x g4dn.12xlarge GPU nodes (Tesla T4, 4 GPUs each), NFS storage class

```

**TestMultiNodeOpenMPITrainJob:** PASS (27s) - 2 MPI ranks ran on 2 separate GPU nodes, launcher/worker SSH established, PyTorch 2.10.0 + CUDA confirmed on both ranks

```
=== RUN   TestMultiNodeOpenMPITrainJob
    trainer_mpi_test.go:40: Created MPI TrainJob test-ns-ckn99/test-mpi-trainjob-fnltl successfully
    trainer_mpi_test.go:50: MPI TrainJob test-ns-ckn99/test-mpi-trainjob-fnltl completed successfully
    trainer_mpi_test.go:66: Launcher pod logs:
        Warning: Permanently added '[test-mpi-trainjob-fnltl-node-0-0.test-mpi-trainjob-fnltl]:2222' (ECDSA) to the list of known hosts.
        [Rank 0/2] Running on test-mpi-trainjob-fnltl-launcher-0-0
        [Rank 1/2] Running on test-mpi-trainjob-fnltl-node-0-0
        [Rank 0/2] PyTorch 2.10.0, CUDA available: True
        [Rank 0/2] MPI TrainJob test PASSED
        [Rank 1/2] PyTorch 2.10.0, CUDA available: True
        [Rank 1/2] MPI TrainJob test PASSED
--- PASS: TestMultiNodeOpenMPITrainJob (26.99s)
PASS
ok      github.com/opendatahub-io/distributed-workloads/tests/trainer   30.413s
```
```

**TestDefaultClusterTrainingRuntimes:** Validates `openmpi-cuda` presence and image on cluster

**TestRunTrainJobWithDefaultClusterTrainingRuntimes:** Confirms MPI runtimes are delegated to the dedicated test

**Commands used:**
```bash
go test -run TestMultiNodeOpenMPITrainJob -v -timeout 60m -count=1 ./tests/trainer/
go test -run TestDefaultClusterTrainingRuntimes -v -timeout 60m -count=1 ./tests/trainer/
go test -run TestRunTrainJobWithDefaultClusterTrainingRuntimes -v -timeout 60m -count=1 ./tests/trainer/
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced integration testing for multi-node training scenarios with improved runtime validation.
  * Added comprehensive test coverage for distributed training job execution and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->