### PR TITLE
Add GPU availability tags to PyTorchDDP training tests

### DIFF
--- a/tests/trainer/trainer_fashion_mnist_training_test.go
+++ b/tests/trainer/trainer_fashion_mnist_training_test.go
@@ -42,42 +42,42 @@ func TestPyTorchDDPMultiNodeMultiCPUWithTorchCuda28(t *testing.T) {
 }
 
 func TestPyTorchDDPSingleNodeSingleGPUWithTorchCuda(t *testing.T) {
-	Tags(t, KftoCuda)
+	Tags(t, KftoCuda, Gpu(NVIDIA))
 	runPyTorchDDPMultiNodeJob(t, NVIDIA, trainerutils.DefaultClusterTrainingRuntimeCUDA, "resources/requirements-cuda.txt", 1, 1)
 }
 
 func TestPyTorchDDPSingleNodeMultiGPUWithTorchCuda(t *testing.T) {
-	Tags(t, KftoCuda)
+	Tags(t, KftoCuda, MultiGpu(NVIDIA, 2))
 	runPyTorchDDPMultiNodeJob(t, NVIDIA, trainerutils.DefaultClusterTrainingRuntimeCUDA, "resources/requirements-cuda.txt", 1, 2)
 }
 
 func TestPyTorchDDPMultiNodeSingleGPUWithTorchCuda(t *testing.T) {
-	Tags(t, KftoCuda)
+	Tags(t, KftoCuda, MultiNodeGpu(2, NVIDIA))
 	runPyTorchDDPMultiNodeJob(t, NVIDIA, trainerutils.DefaultClusterTrainingRuntimeCUDA, "resources/requirements-cuda.txt", 2, 1)
 }
 
 func TestPyTorchDDPMultiNodeMultiGPUWithTorchCuda(t *testing.T) {
-	Tags(t, KftoCuda)
+	Tags(t, KftoCuda, MultiNodeMultiGpu(2, NVIDIA, 2))
 	runPyTorchDDPMultiNodeJob(t, NVIDIA, trainerutils.DefaultClusterTrainingRuntimeCUDA, "resources/requirements-cuda.txt", 2, 2)
 }
 
 func TestPyTorchDDPSingleNodeSingleGPUWithTorchRocm(t *testing.T) {
-	Tags(t, KftoRocm)
+	Tags(t, KftoRocm, Gpu(AMD))
 	runPyTorchDDPMultiNodeJob(t, AMD, trainerutils.DefaultClusterTrainingRuntimeROCm, "resources/requirements-rocm.txt", 1, 1)
 }
 
 func TestPyTorchDDPSingleNodeMultiGPUWithTorchRocm(t *testing.T) {
-	Tags(t, KftoRocm)
+	Tags(t, KftoRocm, MultiGpu(AMD, 2))
 	runPyTorchDDPMultiNodeJob(t, AMD, trainerutils.DefaultClusterTrainingRuntimeROCm, "resources/requirements-rocm.txt", 1, 2)
 }
 
 func TestPyTorchDDPMultiNodeSingleGPUWithTorchRocm(t *testing.T) {
-	Tags(t, KftoRocm)
+	Tags(t, KftoRocm, MultiNodeGpu(2, AMD))
 	runPyTorchDDPMultiNodeJob(t, AMD, trainerutils.DefaultClusterTrainingRuntimeROCm, "resources/requirements-rocm.txt", 2, 1)
 }
 
 func TestPyTorchDDPMultiNodeMultiGPUWithTorchRocm(t *testing.T) {
-	Tags(t, KftoRocm)
+	Tags(t, KftoRocm, MultiNodeMultiGpu(2, AMD, 2))
 	runPyTorchDDPMultiNodeJob(t, AMD, trainerutils.DefaultClusterTrainingRuntimeROCm, "resources/requirements-rocm.txt", 2, 2)
 }
 


### PR DESCRIPTION
## Summary
- PyTorchDDP GPU tests were missing GPU/node availability tags (`Gpu()`, `MultiGpu()`, `MultiNodeGpu()`, `MultiNodeMultiGpu()`), causing them to fail with `FailedScheduling` on clusters without sufficient GPUs instead of being gracefully skipped
- Adds appropriate tags to all 8 GPU test functions (4 CUDA, 4 ROCm) matching each test's actual node and GPU requirements

## Test plan
- [x] `go vet ./tests/trainer/...` passes
- [ ] Verify tests are skipped on clusters with insufficient GPUs instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated GPU-focused distributed training tests with more granular hardware and topology tagging to enable better test categorization and organization across single-GPU, multi-GPU, and multi-node configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->