### PR TITLE
task(RHOAIENG-56172): Revise quality gates for Training Kubeflow tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Namespace-scoped resources are deleted automatically when the test namespace is 
 
 ```go
 func TestMyFeature(t *testing.T) {
-    Tags(t, Sanity)        // 1. tag / skip checks
+    Tags(t, Tier1)         // 1. tag / skip checks
     test := With(t)        // 2. create test context
 
     namespace := test.NewTestNamespace().Name  // 3. isolated namespace
@@ -121,7 +121,6 @@ Tests in `tests/trainer/` **must** declare a tag — this is mandatory. Apply it
 | Tag | When to use |
 |-----|-------------|
 | `Smoke` | Minimal deployment verification |
-| `Sanity` | Core workflow correctness |
 | `Tier1`–`Tier3` | Progressively deeper coverage |
 | `Gpu(accelerator)` | Requires at least one GPU node |
 | `MultiGpu(accelerator, n)` | Requires n GPUs per node |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 * `TEST_TIMEOUT_LONG` - Timeout duration for long tasks
 * `TEST_RAY_IMAGE` (Optional) - Ray image used for raycluster configuration
 * `MINIO_CLI_IMAGE` (Optional) - Minio CLI image used for uploading/downloading data from/into s3 bucket
-* `TEST_TIER` (Optional) - Specifies test tier to run, skipping tests which don't belong to specified test tier. Supported test tiers: Smoke, Sanity, Tier1, Tier2, Tier3, Pre-Upgrade and Post-Upgrade. Test tier can also be provided using test parameter `testTier`.
+* `TEST_TIER` (Optional) - Specifies test tier to run, skipping tests which don't belong to specified test tier. Supported test tiers: Smoke, Tier1, Tier2, Tier3, Pre-Upgrade and Post-Upgrade. Test tier can also be provided using test parameter `testTier`.
 
     NOTE: `quay.io/modh/ray:2.47.1-py312-cu128` is the default image used for creating a RayCluster resource. If you have your own custom ray image which suits your purposes, specify it in `TEST_RAY_IMAGE` environment variable.
 

--- a/tests/common/environment.go
+++ b/tests/common/environment.go
@@ -53,7 +53,6 @@ const (
 
 const (
 	tierSmoke    = "Smoke"
-	tierSanity   = "Sanity"
 	tier1        = "Tier1"
 	tier2        = "Tier2"
 	tier3        = "Tier3"
@@ -65,7 +64,7 @@ const (
 	examplesRocm = "Examples-ROCm"
 )
 
-var testTiers = []string{tierSmoke, tierSanity, tier1, tier2, tier3, preUpgrade, postUpgrade, kftoCuda, kftoRocm, examplesCuda, examplesRocm}
+var testTiers = []string{tierSmoke, tier1, tier2, tier3, preUpgrade, postUpgrade, kftoCuda, kftoRocm, examplesCuda, examplesRocm}
 
 var testTierParam string
 

--- a/tests/common/test_tag.go
+++ b/tests/common/test_tag.go
@@ -45,10 +45,6 @@ var Smoke = func(test Test) (runTest bool, skipReason string) {
 	return testTier(test, tierSmoke)
 }
 
-var Sanity = func(test Test) (runTest bool, skipReason string) {
-	return testTier(test, tierSanity)
-}
-
 var Tier1 = func(test Test) (runTest bool, skipReason string) {
 	return testTier(test, tier1)
 }

--- a/tests/kfto/kfto_mnist_sdk_test.go
+++ b/tests/kfto/kfto_mnist_sdk_test.go
@@ -36,19 +36,19 @@ import (
 )
 
 func TestMnistSDKPyTorch241(t *testing.T) {
-	Tags(t, Tier1)
+	Tags(t, Tier2)
 	test := With(t)
 	runMnistSDK(test, GetTrainingCudaPyTorch241Image(test))
 }
 
 func TestMnistSDKPyTorch251(t *testing.T) {
-	Tags(t, Tier1)
+	Tags(t, Tier2)
 	test := With(t)
 	runMnistSDK(test, GetTrainingCudaPyTorch251Image(test))
 }
 
 func TestMnistSDKPyTorch28(t *testing.T) {
-	Tags(t, Tier1)
+	Tags(t, Tier2)
 	test := With(t)
 	runMnistSDK(test, GetTrainingCudaPyTorch28Image(test))
 }

--- a/tests/kfto/kfto_mnist_training_test.go
+++ b/tests/kfto/kfto_mnist_training_test.go
@@ -34,13 +34,13 @@ import (
 )
 
 func TestPyTorchJobMnistMultiNodeSingleCpu(t *testing.T) {
-	Tags(t, Sanity, MultiNode(3))
+	Tags(t, Tier1, MultiNode(3))
 	test := With(t)
 	runKFTOPyTorchMnistJob(test, CPU, GetTrainingCudaPyTorch251Image(test), "resources/requirements.txt", 2, 1)
 }
 
 func TestPyTorchJobMnistMultiNodeMultiCpu(t *testing.T) {
-	Tags(t, Tier1, MultiNode(3))
+	Tags(t, Tier2, MultiNode(3))
 	test := With(t)
 	runKFTOPyTorchMnistJob(test, CPU, GetTrainingCudaPyTorch251Image(test), "resources/requirements.txt", 2, 2)
 }

--- a/tests/kfto/kfto_pytorchjob_failed_test.go
+++ b/tests/kfto/kfto_pytorchjob_failed_test.go
@@ -16,25 +16,25 @@ import (
 )
 
 func TestPyTorchJobFailureWithCudaPyTorch241(t *testing.T) {
-	Tags(t, Tier1)
+	Tags(t, Tier2)
 	test := With(t)
 	runFailedPyTorchJobTest(test, GetTrainingCudaPyTorch241Image(test))
 }
 
 func TestPyTorchJobFailureWithCudaPyTorch251(t *testing.T) {
-	Tags(t, Tier1)
+	Tags(t, Tier2)
 	test := With(t)
 	runFailedPyTorchJobTest(test, GetTrainingCudaPyTorch251Image(test))
 }
 
 func TestPyTorchJobFailureWithROCmPyTorch241(t *testing.T) {
-	Tags(t, Tier1)
+	Tags(t, Tier2)
 	test := With(t)
 	runFailedPyTorchJobTest(test, GetTrainingROCmPyTorch241Image(test))
 }
 
 func TestPyTorchJobFailureWithROCmPyTorch251(t *testing.T) {
-	Tags(t, Tier1)
+	Tags(t, Tier2)
 	test := With(t)
 	runFailedPyTorchJobTest(test, GetTrainingROCmPyTorch251Image(test))
 }

--- a/tests/kfto/kfto_training_test.go
+++ b/tests/kfto/kfto_training_test.go
@@ -33,19 +33,19 @@ import (
 )
 
 func TestPyTorchJobSingleNodeSingleGpuWithCudaPyTorch241(t *testing.T) {
-	Tags(t, Tier1, Gpu(NVIDIA))
+	Tags(t, Tier2, Gpu(NVIDIA))
 	test := With(t)
 	runKFTOPyTorchJob(test, GetTrainingCudaPyTorch241Image(test), NVIDIA, 1, 0)
 }
 
 func TestPyTorchJobSingleNodeSingleGpuWithCudaPyTorch251(t *testing.T) {
-	Tags(t, Tier1, Gpu(NVIDIA))
+	Tags(t, Tier2, Gpu(NVIDIA))
 	test := With(t)
 	runKFTOPyTorchJob(test, GetTrainingCudaPyTorch251Image(test), NVIDIA, 1, 0)
 }
 
 func TestPyTorchJobSingleNodeSingleGpuWithCudaPyTorch28(t *testing.T) {
-	Tags(t, Tier1, Gpu(NVIDIA))
+	Tags(t, Tier2, Gpu(NVIDIA))
 	test := With(t)
 	runKFTOPyTorchJob(test, GetTrainingCudaPyTorch28Image(test), NVIDIA, 1, 0)
 }
@@ -105,19 +105,19 @@ func TestPyTorchJobMultiNodeMultiGpuWithCudaPyTorch28(t *testing.T) {
 }
 
 func TestPyTorchJobSingleNodeSingleGpuWithROCmPyTorch241(t *testing.T) {
-	Tags(t, Tier1, Gpu(AMD))
+	Tags(t, Tier2, Gpu(AMD))
 	test := With(t)
 	runKFTOPyTorchJob(test, GetTrainingROCmPyTorch241Image(test), AMD, 1, 0)
 }
 
 func TestPyTorchJobSingleNodeSingleGpuWithROCmPyTorch251(t *testing.T) {
-	Tags(t, Tier1, Gpu(AMD))
+	Tags(t, Tier2, Gpu(AMD))
 	test := With(t)
 	runKFTOPyTorchJob(test, GetTrainingROCmPyTorch251Image(test), AMD, 1, 0)
 }
 
 func TestPyTorchJobSingleNodeSingleGpuWithROCmPyTorch28(t *testing.T) {
-	Tags(t, Tier1, Gpu(AMD))
+	Tags(t, Tier2, Gpu(AMD))
 	test := With(t)
 	runKFTOPyTorchJob(test, GetTrainingRocmPyTorch28Image(test), AMD, 1, 0)
 }

--- a/tests/trainer/cluster_training_runtimes_test.go
+++ b/tests/trainer/cluster_training_runtimes_test.go
@@ -174,7 +174,7 @@ func TestDefaultTrainingHubRuntimesMatchDefaultClusterRuntimes(t *testing.T) {
 }
 
 func TestRunTrainJobWithDefaultClusterTrainingRuntimes(t *testing.T) {
-	Tags(t, Sanity)
+	Tags(t, Tier1)
 	test := With(t)
 
 	// Run one TrainJob per unique image to avoid redundant runs for CTRs that share the same image

--- a/tests/trainer/jobset_workflow_test.go
+++ b/tests/trainer/jobset_workflow_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestJobSetWorkflow(t *testing.T) {
-	Tags(t, Sanity)
+	Tags(t, Tier1)
 	test := With(t)
 
 	// Create a namespace
@@ -71,7 +71,7 @@ func TestJobSetWorkflow(t *testing.T) {
 }
 
 func TestFailedJobSetWorkflow(t *testing.T) {
-	Tags(t, Sanity)
+	Tags(t, Tier2)
 	test := With(t)
 
 	// Create a namespace

--- a/tests/trainer/kubeflow_sdk_test.go
+++ b/tests/trainer/kubeflow_sdk_test.go
@@ -24,13 +24,13 @@ import (
 	sdktests "github.com/opendatahub-io/distributed-workloads/tests/trainer/sdk_tests"
 )
 
-func TestKubeflowSdkSanity(t *testing.T) {
-	Tags(t, Sanity)
+func TestKubeflowSdk(t *testing.T) {
+	Tags(t, Tier1)
 	sdktests.RunFashionMnistCpuDistributedTraining(t)
 }
 
 func TestKubeflowSdkKueueIntegration(t *testing.T) {
-	Tags(t, Sanity)
+	Tags(t, Tier1)
 	test := support.With(t)
 	support.SetupKueue(test, initialKueueState, support.TrainJobFramework)
 	sdktests.RunFashionMnistKueueCpuDistributedTraining(t)
@@ -78,17 +78,17 @@ func TestSftTrainingHubMultiNodeMultiGPU(t *testing.T) {
 
 // CPU tests - 1 node, 1 CPU each
 func TestRhaiTrainingProgressionCPU(t *testing.T) {
-	Tags(t, Tier1)
+	Tags(t, Tier2)
 	sdktests.RunRhaiFeaturesProgressionTest(t, support.CPU, 1)
 }
 
 func TestRhaiJitCheckpointingCPU(t *testing.T) {
-	Tags(t, Tier1)
+	Tags(t, Tier2)
 	sdktests.RunRhaiFeaturesCheckpointTest(t, support.CPU, 1)
 }
 
 func TestRhaiFeaturesCPU(t *testing.T) {
-	Tags(t, Tier1)
+	Tags(t, Tier2)
 	sdktests.RunRhaiFeaturesAllTest(t, support.CPU, 1)
 }
 
@@ -172,7 +172,7 @@ func TestTorchrunTrainingFailure(t *testing.T) {
 
 // S3 Checkpoint tests (CPU only, auto-skip if S3 not configured)
 func TestRhaiS3CheckpointingCPU(t *testing.T) {
-	Tags(t, Tier1)
+	Tags(t, Tier2)
 	sdktests.RunRhaiS3CheckpointTest(t, support.CPU, 1)
 }
 

--- a/tests/trainer/trainer_fashion_mnist_training_test.go
+++ b/tests/trainer/trainer_fashion_mnist_training_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestPyTorchDDPMultiNodeMultiCPUWithTorchCuda28(t *testing.T) {
-	Tags(t, Tier1, MultiNode(2))
+	Tags(t, Tier2, MultiNode(2))
 	runPyTorchDDPMultiNodeJob(t, CPU, trainerutils.DefaultClusterTrainingRuntimeCPU, "resources/requirements-cpu.txt", 2, 2)
 }
 

--- a/tests/trainer/trainer_kueue_integration_test.go
+++ b/tests/trainer/trainer_kueue_integration_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestKueueDefaultLocalQueueLabelInjection(t *testing.T) {
-	Tags(t, Sanity)
+	Tags(t, Tier1)
 	test := With(t)
 	SetupKueue(test, initialKueueState, TrainJobFramework)
 
@@ -137,7 +137,7 @@ func TestKueueDefaultLocalQueueLabelInjection(t *testing.T) {
 }
 
 func TestKueueWorkloadPreemptionSuspendsTrainJob(t *testing.T) {
-	Tags(t, Sanity)
+	Tags(t, Tier1)
 	test := With(t)
 	SetupKueue(test, initialKueueState, TrainJobFramework)
 
@@ -223,7 +223,7 @@ func TestKueueWorkloadPreemptionSuspendsTrainJob(t *testing.T) {
 }
 
 func TestKueueWorkloadInadmissibleWithNonExistentLocalQueue(t *testing.T) {
-	Tags(t, Sanity)
+	Tags(t, Tier2)
 	test := With(t)
 	SetupKueue(test, initialKueueState, TrainJobFramework)
 


### PR DESCRIPTION
## Summary
- Retire `Sanity` quality gate and redistribute tests to `Tier1` and `Tier2`
- Promote positive `Sanity` tests (core workflows, SDK, Kueue integration) to `Tier1`
- Move former `Tier1` tests to `Tier2` to keep Tier1 lighter and faster
- Place negative/failure tests in `Tier2`
- Remove `Sanity` tag constant and tier value from the test framework

## Test plan
- [x] Verify no `Sanity` tag usage remains (`grep -rn 'Sanity' tests/` — no results)
- [x] Verify all test packages compile cleanly (`go build ./tests/common/ ./tests/trainer/ ./tests/kfto/ ./tests/odh/ ./tests/fms/`)
- [x] Verify `TEST_TIER=Sanity` is rejected as invalid — framework reports: `invalid value: 'Sanity'. Valid values are: [Smoke Tier1 Tier2 Tier3 ...]`
- [x] Verify `TEST_TIER=Tier1` selects correct trainer tests (former positive Sanity tests selected, former Tier1/negative/GPU/Smoke/upgrade tests skipped)
- [x] Verify `TEST_TIER=Tier2` selects correct trainer tests (former Tier1 CPU tests + negative tests selected, Tier1/Smoke/GPU/upgrade tests skipped)
- [ ] Run Tier1/Tier2 on a live cluster to confirm end-to-end execution (requires RHOAI cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed Sanity test tier classification; tests reclassified to Tier1 and Tier2
  * Updated test metadata tags across multiple test suites

* **Documentation**
  * Updated test tier guidance and environment variable documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->