### PR TITLE
RHOAIENG-60624: fix nvidia GPU tests

### DIFF
--- a/tests/odh/mnist_ray_test.go
+++ b/tests/odh/mnist_ray_test.go
@@ -65,7 +65,7 @@ func mnistRay(t *testing.T, numGpus int, gpuResourceName string, rayImage string
 	test := With(t)
 
 	// Create a namespace
-	namespace := test.NewTestNamespace()
+	namespace := test.NewTestNamespace(WithKueueManaged())
 
 	// Ensure Notebook ServiceAccount exists (no extra RBAC)
 	ensureNotebookServiceAccount(test, namespace.Name)

--- a/tests/odh/mnist_raytune_hpo_test.go
+++ b/tests/odh/mnist_raytune_hpo_test.go
@@ -45,7 +45,7 @@ func mnistRayTuneHpo(t *testing.T, numGpus int) {
 	test := With(t)
 
 	// Creating a namespace
-	namespace := test.NewTestNamespace()
+	namespace := test.NewTestNamespace(WithKueueManaged())
 
 	// Ensure Notebook ServiceAccount exists (no extra RBAC)
 	ensureNotebookServiceAccount(test, namespace.Name)
@@ -72,7 +72,7 @@ func mnistRayTuneHpo(t *testing.T, numGpus int) {
 							},
 							{
 								Name:         corev1.ResourceName("nvidia.com/gpu"),
-								NominalQuota: resource.MustParse(fmt.Sprint(numGpus)),
+								NominalQuota: resource.MustParse(fmt.Sprint(numGpus * 2)), // 2 workers x numGpus each
 							},
 						},
 					},

--- a/tests/odh/ray_finetune_llm_deepspeed_test.go
+++ b/tests/odh/ray_finetune_llm_deepspeed_test.go
@@ -44,7 +44,7 @@ func rayFinetuneLlmDeepspeed(t *testing.T, numGpus int, modelName string, modelC
 	test := With(t)
 
 	// Create a namespace
-	namespace := test.NewTestNamespace()
+	namespace := test.NewTestNamespace(WithKueueManaged())
 	var workingDirectory, err = os.Getwd()
 	test.Expect(err).ToNot(HaveOccurred())
 

--- a/tests/odh/raytune_oai_mr_grpc_test.go
+++ b/tests/odh/raytune_oai_mr_grpc_test.go
@@ -46,7 +46,7 @@ func raytuneHpo(t *testing.T, numGpus int) {
 	test := With(t)
 
 	// Create a namespace
-	namespace := test.NewTestNamespace()
+	namespace := test.NewTestNamespace(WithKueueManaged())
 
 	// Ensure Notebook ServiceAccount exists (no extra RBAC)
 	ensureNotebookServiceAccount(test, namespace.Name)

--- a/tests/odh/resources/mnist_hpo.py
+++ b/tests/odh/resources/mnist_hpo.py
@@ -171,7 +171,7 @@ def train_mnist(config):
         model.parameters(), lr=config["lr"], momentum=config["momentum"]
     )
 
-    while True:
+    for _ in range(5):
         train_func(model, optimizer, train_loader, device)
         acc = test_func(model, test_loader, device)
         metrics = {"mean_accuracy": acc}
@@ -180,12 +180,33 @@ def train_mnist(config):
         if should_checkpoint:
             with tempfile.TemporaryDirectory() as tempdir:
                 torch.save(model.state_dict(), os.path.join(tempdir, "model.pt"))
-                train.report(metrics, checkpoint=Checkpoint.from_directory(tempdir))
+                tune.report(metrics, checkpoint=Checkpoint.from_directory(tempdir))
         else:
-            train.report(metrics)
+            tune.report(metrics)
 
 
 if __name__ == "__main__":
+    import os as _os
+    # Ray 2.35.0's get_air_verbosity() expects int or AirVerbosity enum, but the
+    # RHOAI cluster sets AIR_VERBOSITY as a plain string. Patch at the source so
+    # it works regardless of when/how the env-var is re-injected (e.g. via ray.init).
+    try:
+        import ray.tune.experimental.output as _ray_output
+        import ray.tune.tune as _ray_tune_module
+        _orig_gav = _ray_output.get_air_verbosity
+        def _fixed_gav(verbose):
+            if isinstance(verbose, str):
+                try:
+                    verbose = int(verbose)
+                except (ValueError, TypeError):
+                    verbose = 2
+            return _orig_gav(verbose)
+        _ray_output.get_air_verbosity = _fixed_gav
+        _ray_tune_module.get_air_verbosity = _fixed_gav
+    except Exception:
+        pass
+    _os.environ.pop("AIR_VERBOSITY", None)
+
     # for early stopping
     sched = AsyncHyperBandScheduler()
     gpu_value=int("has to be specified")
@@ -198,12 +219,8 @@ if __name__ == "__main__":
             scheduler=sched,
             num_samples=5,
         ),
-        run_config=train.RunConfig(
+        run_config=tune.RunConfig(
             name="exp",
-            stop={
-                "mean_accuracy": 0.98,
-                "training_iteration": 5,
-            },
         ),
         param_space={
             "lr": tune.loguniform(1e-4, 1e-2),

--- a/tests/odh/resources/mnist_hpo_raytune.ipynb
+++ b/tests/odh/resources/mnist_hpo_raytune.ipynb
@@ -1,260 +1,265 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b55bc3ea-4ce3-49bf-bb1f-e209de8ca47a",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import yaml\n",
-    "\n",
-    "# Import pieces from codeflare-sdk\n",
-    "from codeflare_sdk import Cluster, ClusterConfiguration, TokenAuthentication\n",
-    "from codeflare_sdk.ray.client import RayJobClient\n",
-    "from time import sleep"
-   ]
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "import os\n",
+        "import yaml\n",
+        "\n",
+        "# Import pieces from codeflare-sdk\n",
+        "from codeflare_sdk import Cluster, ClusterConfiguration, TokenAuthentication\n",
+        "from codeflare_sdk.ray.client import RayJobClient\n",
+        "from time import sleep"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "b55bc3ea-4ce3-49bf-bb1f-e209de8ca47a"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%pip show codeflare-sdk"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "f6fb4c03"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "parameters"
+        ]
+      },
+      "source": [
+        "#parameters\n",
+        "namespace = \"default\"\n",
+        "ray_image = \"has to be specified\"\n",
+        "openshift_api_url = \"has to be specified\"\n",
+        "kubernetes_user_bearer_token = \"has to be specified\"\n",
+        "num_gpus = \"has to be specified\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "30888aed"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "auth = TokenAuthentication(\n",
+        "    token=kubernetes_user_bearer_token,\n",
+        "    server=openshift_api_url,\n",
+        "    skip_tls=True,\n",
+        ")\n",
+        "auth.login()"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "a0538160"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "# Create ray cluster\n",
+        "# HPO runs num_samples=5 trials, each needing 1 CPU, so we need more resources\n",
+        "cluster = Cluster(\n",
+        "    ClusterConfiguration(\n",
+        "        namespace=namespace,\n",
+        "        name='mnisthpotest',\n",
+        "        head_cpu_requests=2,\n",
+        "        head_cpu_limits=2,\n",
+        "        head_memory_requests=8,\n",
+        "        head_memory_limits=10,\n",
+        "        head_extended_resource_requests={'nvidia.com/gpu':0},\n",
+        "        num_workers=2,\n",
+        "        worker_cpu_requests=2,\n",
+        "        worker_cpu_limits=2,\n",
+        "        worker_memory_requests=2,\n",
+        "        worker_memory_limits=6,\n",
+        "        worker_extended_resource_requests={'nvidia.com/gpu':int(num_gpus)},\n",
+        "        image=ray_image,\n",
+        "        write_to_file=True,\n",
+        "        verify_tls=False\n",
+        "    )\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "0f4bc870-091f-4e11-9642-cba145710159"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "directory_path = os.path.expanduser(\"~/.codeflare/resources/\")\n",
+        "outfile = os.path.join(directory_path, \"mnisthpotest.yaml\")\n",
+        "cluster_yaml = None\n",
+        "with open(outfile) as f:\n",
+        "    cluster_yaml = yaml.load(f, yaml.FullLoader)\n",
+        "\n",
+        "# Add toleration for GPU nodes to Ray cluster worker pod\n",
+        "cluster_yaml[\"spec\"][\"workerGroupSpecs\"][0][\"template\"][\"spec\"][\"tolerations\"]=[{\"key\": \"nvidia.com/gpu\", \"value\": \"NONE\", \"effect\": \"NoSchedule\"}]\n",
+        "\n",
+        "with open(outfile, \"w\") as f:\n",
+        "    yaml.dump(cluster_yaml, f, default_flow_style=False)"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "04a5ea40"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "# Bring up the cluster\n",
+        "cluster.up()\n",
+        "# Wait until status is updated (skip dashboard check as route naming changed in kuberay operator)\n",
+        "cluster.wait_ready(dashboard_check=False)"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "f0884bbc-c224-4ca0-98a0-02dfa09c2200"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "cluster.status()"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "df71c1ed"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "cluster.details()"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "7fd45bc5-03c0-4ae5-9ec5-dd1c30f1a084"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Access dashboard directly via internal service (notebook runs inside the cluster)\n",
+        "# The service mnisthpotest-head-svc exposes the Ray dashboard on port 8265\n",
+        "ray_dashboard = f\"http://mnisthpotest-head-svc.{namespace}.svc.cluster.local:8265\"\n",
+        "print(f\"Ray dashboard URL: {ray_dashboard}\")\n",
+        "\n",
+        "header = {\"Authorization\": f\"Bearer {kubernetes_user_bearer_token}\"}\n",
+        "client = RayJobClient(address=ray_dashboard, headers=header, verify=False)\n",
+        "\n",
+        "submission_id = client.submit_job(\n",
+        "    entrypoint=\"python mnist_hpo.py\",\n",
+        "    runtime_env={\n",
+        "        \"env_vars\": {\n",
+        "            \"PIP_INDEX_URL\":os.environ.get(\"PIP_INDEX_URL\"),\n",
+        "            \"PIP_TRUSTED_HOST\":os.environ.get(\"PIP_TRUSTED_HOST\"),\n",
+        "        },\n",
+        "        \"working_dir\": \"/opt/app-root/notebooks/..data\",\n",
+        "        \"pip\": \"/opt/app-root/notebooks/hpo_raytune_requirements.txt\",\n",
+        "    },\n",
+        "    # entrypoint_num_gpus is not required here as the mnist_hpo script executes in parallel and requires more GPUs for each iteration\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "47ca5c15"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import requests\n",
+        "status = None\n",
+        "error_count = 0\n",
+        "max_errors = 60  # Max consecutive errors before giving up\n",
+        "\n",
+        "while status != \"SUCCEEDED\":\n",
+        "    sleep(1)\n",
+        "    try:\n",
+        "        status = client.get_job_status(submission_id)\n",
+        "        error_count = 0  # Reset on success\n",
+        "        print(f\"Job status: {status}\")\n",
+        "        if status == \"FAILED\":\n",
+        "            print(\"Job failed!\")\n",
+        "            try:\n",
+        "                logs = client.get_job_logs(submission_id)\n",
+        "                print(f\"=== JOB LOGS ===\\n{logs[-8000:]}\\n=== END LOGS ===\")\n",
+        "            except Exception as log_err:\n",
+        "                print(f\"Could not fetch job logs: {log_err}\")\n",
+        "            break\n",
+        "    except (RuntimeError, requests.exceptions.ConnectionError, ConnectionError) as e:\n",
+        "        error_count += 1\n",
+        "        print(f\"Transient error ({error_count}/{max_errors}) checking job status: {type(e).__name__}: {e}\")\n",
+        "        if error_count >= max_errors:\n",
+        "            print(f\"Too many consecutive errors, giving up\")\n",
+        "            break\n",
+        "        continue\n",
+        "\n",
+        "if status == \"SUCCEEDED\":\n",
+        "    print(\"Job completed Successfully !\")\n",
+        "else:\n",
+        "    print(f\"Job did not succeed. Final status: {status}\")\n",
+        "\n",
+        "sleep(10) # Brief pause before cleanup"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "f63a178a"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "cluster.down()"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "6b099777"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.18"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "f9f85f796d01129d0dd105a088854619f454435301f6ffec2fea96ecbd9be4ac"
+      }
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f6fb4c03",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip show codeflare-sdk"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "30888aed",
-   "metadata": {
-    "tags": [
-     "parameters"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "#parameters\n",
-    "namespace = \"default\"\n",
-    "ray_image = \"has to be specified\"\n",
-    "openshift_api_url = \"has to be specified\"\n",
-    "kubernetes_user_bearer_token = \"has to be specified\"\n",
-    "num_gpus = \"has to be specified\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a0538160",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "auth = TokenAuthentication(\n",
-    "    token=kubernetes_user_bearer_token,\n",
-    "    server=openshift_api_url,\n",
-    "    skip_tls=True,\n",
-    ")\n",
-    "auth.login()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0f4bc870-091f-4e11-9642-cba145710159",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Create ray cluster\n",
-    "# HPO runs num_samples=5 trials, each needing 1 CPU, so we need more resources\n",
-    "cluster = Cluster(\n",
-    "    ClusterConfiguration(\n",
-    "        namespace=namespace,\n",
-    "        name='mnisthpotest',\n",
-    "        head_cpu_requests=2,\n",
-    "        head_cpu_limits=2,\n",
-    "        head_memory_requests=8,\n",
-    "        head_memory_limits=10,\n",
-    "        head_extended_resource_requests={'nvidia.com/gpu':0},\n",
-    "        num_workers=2,\n",
-    "        worker_cpu_requests=2,\n",
-    "        worker_cpu_limits=2,\n",
-    "        worker_memory_requests=2,\n",
-    "        worker_memory_limits=6,\n",
-    "        worker_extended_resource_requests={'nvidia.com/gpu':int(num_gpus)},\n",
-    "        image=ray_image,\n",
-    "        write_to_file=True,\n",
-    "        verify_tls=False\n",
-    "    )\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "04a5ea40",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "directory_path = os.path.expanduser(\"~/.codeflare/resources/\")\n",
-    "outfile = os.path.join(directory_path, \"mnisthpotest.yaml\")\n",
-    "cluster_yaml = None\n",
-    "with open(outfile) as f:\n",
-    "    cluster_yaml = yaml.load(f, yaml.FullLoader)\n",
-    "\n",
-    "# Add toleration for GPU nodes to Ray cluster worker pod\n",
-    "cluster_yaml[\"spec\"][\"workerGroupSpecs\"][0][\"template\"][\"spec\"][\"tolerations\"]=[{\"key\": \"nvidia.com/gpu\", \"value\": \"NONE\", \"effect\": \"NoSchedule\"}]\n",
-    "\n",
-    "with open(outfile, \"w\") as f:\n",
-    "    yaml.dump(cluster_yaml, f, default_flow_style=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f0884bbc-c224-4ca0-98a0-02dfa09c2200",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Bring up the cluster\n",
-    "cluster.up()\n",
-    "# Wait until status is updated (skip dashboard check as route naming changed in kuberay operator)\n",
-    "cluster.wait_ready(dashboard_check=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "df71c1ed",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "cluster.status()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7fd45bc5-03c0-4ae5-9ec5-dd1c30f1a084",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "cluster.details()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "47ca5c15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Access dashboard directly via internal service (notebook runs inside the cluster)\n",
-    "# The service mnisthpotest-head-svc exposes the Ray dashboard on port 8265\n",
-    "ray_dashboard = f\"http://mnisthpotest-head-svc.{namespace}.svc.cluster.local:8265\"\n",
-    "print(f\"Ray dashboard URL: {ray_dashboard}\")\n",
-    "\n",
-    "header = {\"Authorization\": f\"Bearer {kubernetes_user_bearer_token}\"}\n",
-    "client = RayJobClient(address=ray_dashboard, headers=header, verify=False)\n",
-    "\n",
-    "submission_id = client.submit_job(\n",
-    "    entrypoint=\"python mnist_hpo.py\",\n",
-    "    runtime_env={\n",
-    "        \"env_vars\": {\n",
-    "            \"PIP_INDEX_URL\":os.environ.get(\"PIP_INDEX_URL\"),\n",
-    "            \"PIP_TRUSTED_HOST\":os.environ.get(\"PIP_TRUSTED_HOST\"),\n",
-    "        },\n",
-    "        \"working_dir\": \"/opt/app-root/notebooks/..data\",\n",
-    "        \"pip\": \"/opt/app-root/notebooks/hpo_raytune_requirements.txt\",\n",
-    "    },\n",
-    "    # entrypoint_num_gpus is not required here as the mnist_hpo script executes in parallel and requires more GPUs for each iteration\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f63a178a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import requests\n",
-    "status = None\n",
-    "error_count = 0\n",
-    "max_errors = 60  # Max consecutive errors before giving up\n",
-    "\n",
-    "while status != \"SUCCEEDED\":\n",
-    "    sleep(1)\n",
-    "    try:\n",
-    "        status = client.get_job_status(submission_id)\n",
-    "        error_count = 0  # Reset on success\n",
-    "        print(f\"Job status: {status}\")\n",
-    "        if status == \"FAILED\":\n",
-    "            print(\"Job failed!\")\n",
-    "            break\n",
-    "    except (RuntimeError, requests.exceptions.ConnectionError, ConnectionError) as e:\n",
-    "        error_count += 1\n",
-    "        print(f\"Transient error ({error_count}/{max_errors}) checking job status: {type(e).__name__}: {e}\")\n",
-    "        if error_count >= max_errors:\n",
-    "            print(f\"Too many consecutive errors, giving up\")\n",
-    "            break\n",
-    "        continue\n",
-    "\n",
-    "if status == \"SUCCEEDED\":\n",
-    "    print(\"Job completed Successfully !\")\n",
-    "else:\n",
-    "    print(f\"Job did not succeed. Final status: {status}\")\n",
-    "\n",
-    "sleep(10) # Brief pause before cleanup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6b099777",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cluster.down()"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.18"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "f9f85f796d01129d0dd105a088854619f454435301f6ffec2fea96ecbd9be4ac"
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/tests/odh/resources/requirements.txt
+++ b/tests/odh/resources/requirements.txt
@@ -1,5 +1,4 @@
 pytorch_lightning==1.9.5
-ray_lightning
 torchmetrics==0.9.1
 torchvision==0.19.0
 minio


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
RHOAIENG-60624: fix nvidia GPU tests

## How Has This Been Tested?
Executed against nvidia GPU cluster. see the logs

### GPU tests
```
==============================================================================
Tests                                                                         
==============================================================================
Tests.Distributed Workloads                                                   
==============================================================================
2026-05-01 04:03:26,547 - RPA.core.certificates - INFO - Truststore not in use, HTTPS traffic validated against `certifi` package. (requires Python 3.10.12 and 'pip' 23.2.1 at minimum)
Tests.Distributed Workloads.Test-Run-Distributed-Workloads-Tests :: Distrib...
==============================================================================
"Using pre-existing compiled test binary odh"
"Retrieving user tokens"
"Log back as cluster admin"
Product:RHODS Version:3.3.2
[ WARN ] No Prometheus found
"Applying kueue-batch-user-role ClusterRole"
clusterrole.rbac.authorization.k8s.io/kueue-batch-user-role created
"Applying kueue-batch-user-rolebinding ClusterRoleBinding"
clusterrolebinding.rbac.authorization.k8s.io/kueue-batch-user-rolebinding created
"Applying kueue-batch-user-specific-rolebinding ClusterRoleBinding"
clusterrolebinding.rbac.authorization.k8s.io/kueue-batch-user-specific-rolebinding created
"Applying kueue-batch-notebook-user-specific-rolebinding ClusterRoleBinding"
clusterrolebinding.rbac.authorization.k8s.io/kueue-batch-user-specific-rolebinding configured
"Applying codeflare-sdk-rbac-permissions"
clusterrolebinding.rbac.authorization.k8s.io/test-user-self-provisioner created
clusterrolebinding.rbac.authorization.k8s.io/test-user-admin created
clusterrolebinding.rbac.authorization.k8s.io/test-user-cluster-admin created
clusterrole.rbac.authorization.k8s.io/test-user-kueue-admin created
clusterrolebinding.rbac.authorization.k8s.io/test-user-kueue-admin created
clusterrole.rbac.authorization.k8s.io/test-user-ray-admin created
clusterrolebinding.rbac.authorization.k8s.io/test-user-ray-admin created
"Setting Kueue component to Unmanaged state"
Component kueue state was set to Unmanaged
Waiting for DataScienceCluster CustomResource To Be Ready
DataScienceCluster CustomResource is Ready
Run TestKueueRayCudaGpu ODH test with Python 3.11 :: Run Go ODH te... "Running test: TestMnistRayCudaGpu"
I0501 04:03:49.879599   24810 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:03:50.025660   24810 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:03:50.154532   24810 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:04:43.467659   24810 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:04:46.487890   24810 warnings.go:110] "Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"
I0501 04:07:07.621377   24810 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:07:07.746715   24810 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
PASS
Run TestKueueRayCudaGpu ODH test with Python 3.11 :: Run Go ODH te... | PASS |
------------------------------------------------------------------------------
Run TestRayTuneHPOGpu ODH test with Python 3.11 :: Run Go ODH test... "Running test: TestMnistRayTuneHpoGpu"
I0501 04:07:10.257213   24818 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:07:10.420198   24818 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:07:10.572153   24818 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:07:50.989075   24818 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:07:54.144566   24818 warnings.go:110] "Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"
I0501 04:12:28.225960   24818 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:12:28.354811   24818 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
PASS
Run TestRayTuneHPOGpu ODH test with Python 3.11 :: Run Go ODH test... | PASS |
------------------------------------------------------------------------------
Run TestKueueCustomRayCudaGpu ODH test with Python 3.11 :: Run Go ... "Running test: TestMnistCustomRayCudaGpu"
I0501 04:12:30.962483   24826 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:12:31.106409   24826 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:12:31.250857   24826 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:13:19.191514   24826 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:13:22.246325   24826 warnings.go:110] "Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"
I0501 04:14:51.963011   24826 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:14:52.084444   24826 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
PASS
Run TestKueueCustomRayCudaGpu ODH test with Python 3.11 :: Run Go ... | PASS |
------------------------------------------------------------------------------
"Log back as cluster admin"
"Keeping test binary for reuse (patched build)"
"Keeping Kueue component in Unmanaged state"
Component kueue state was set to Unmanaged
Waiting for DataScienceCluster CustomResource To Be Ready
DataScienceCluster CustomResource is Ready
"Logging in as cluster admin to cleanup RBAC permissions"
"Removing kueue-batch-user-rolebinding ClusterRoleBinding"
clusterrolebinding.rbac.authorization.k8s.io "kueue-batch-user-rolebinding" deleted
"Removing kueue-batch-user-specific-rolebinding ClusterRoleBinding"
clusterrolebinding.rbac.authorization.k8s.io "kueue-batch-user-specific-rolebinding" deleted
"Removing kueue-batch-notebook-user-specific-rolebinding ClusterRoleBinding"
Error from server (NotFound): error when deleting "tests/Resources/Files/kueue-batch-notebook-user-specific-rolebinding.yaml": clusterrolebindings.rbac.authorization.k8s.io "kueue-batch-user-specific-rolebinding" not found
"Warning: Unable to delete kueue-batch-notebook-user-specific-rolebinding ClusterRoleBinding (may not exist)"
"Removing kueue-batch-user-role ClusterRole"
clusterrole.rbac.authorization.k8s.io "kueue-batch-user-role" deleted
"Removing codeflare-sdk-rbac-permissions"
clusterrolebinding.rbac.authorization.k8s.io "test-user-self-provisioner" deleted
clusterrolebinding.rbac.authorization.k8s.io "test-user-admin" deleted
clusterrolebinding.rbac.authorization.k8s.io "test-user-cluster-admin" deleted
clusterrole.rbac.authorization.k8s.io "test-user-kueue-admin" deleted
clusterrolebinding.rbac.authorization.k8s.io "test-user-kueue-admin" deleted
clusterrole.rbac.authorization.k8s.io "test-user-ray-admin" deleted
clusterrolebinding.rbac.authorization.k8s.io "test-user-ray-admin" deleted
Tests.Distributed Workloads.Test-Run-Distributed-Workloads-Tests :... | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Tests.Distributed Workloads                                           | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Output:  /workspace/ods-ci/ods_ci/test-output/ods-ci-2026-05-01-04-03-vua1MyUSye/output.xml
XUnit:   /workspace/ods-ci/ods_ci/test-output/ods-ci-2026-05-01-04-03-vua1MyUSye/xunit_test_result.xml
Log:     /workspace/ods-ci/ods_ci/test-output/ods-ci-2026-05-01-04-03-vua1MyUSye/log.html
Report:  /workspace/ods-ci/ods_ci/test-output/ods-ci-2026-05-01-04-03-vua1MyUSye/test_report.html
0
```

### CPU tests
```
Run TestKueueRayCpu ODH test with Python 3.11 :: Run Go ODH test: ... "Running test: TestMnistRayCpu"
I0501 04:38:31.240656   25318 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:38:31.384344   25318 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:38:31.510690   25318 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:39:12.238687   25318 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:39:15.268082   25318 warnings.go:110] "Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"
I0501 04:41:38.790514   25318 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:41:38.916546   25318 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
PASS
Run TestKueueRayCpu ODH test with Python 3.11 :: Run Go ODH test: ... | PASS |
------------------------------------------------------------------------------
Run TestRayTuneHPOCpu ODH test with Python 3.11 :: Run Go ODH test... "Running test: TestMnistRayTuneHpoCpu"
I0501 04:41:41.278698   25326 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:41:41.516972   25326 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:41:41.675063   25326 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:42:24.780235   25326 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:42:27.812660   25326 warnings.go:110] "Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"
I0501 04:46:52.669246   25326 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:46:52.788741   25326 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
PASS
Run TestRayTuneHPOCpu ODH test with Python 3.11 :: Run Go ODH test... | PASS |
------------------------------------------------------------------------------
Run TestKueueCustomRayCudaCpu ODH test with Python 3.11 :: Run Go ... "Running test: TestMnistCustomRayCudaCpu"
I0501 04:46:55.356566   25334 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:46:55.508706   25334 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:46:55.638636   25334 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:47:41.009354   25334 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:47:44.054146   25334 warnings.go:110] "Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"
I0501 04:49:57.666416   25334 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
I0501 04:49:57.791248   25334 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."
PASS
Run TestKueueCustomRayCudaCpu ODH test with Python 3.11 :: Run Go ... | PASS |
------------------------------------------------------------------------------
"Log back as cluster admin"
"Keeping test binary for reuse (patched build)"
"Keeping Kueue component in Unmanaged state"
Component kueue state was set to Unmanaged
Waiting for DataScienceCluster CustomResource To Be Ready
DataScienceCluster CustomResource is Ready
"Logging in as cluster admin to cleanup RBAC permissions"
"Removing kueue-batch-user-rolebinding ClusterRoleBinding"
clusterrolebinding.rbac.authorization.k8s.io "kueue-batch-user-rolebinding" deleted
"Removing kueue-batch-user-specific-rolebinding ClusterRoleBinding"
clusterrolebinding.rbac.authorization.k8s.io "kueue-batch-user-specific-rolebinding" deleted
"Removing kueue-batch-notebook-user-specific-rolebinding ClusterRoleBinding"
Error from server (NotFound): error when deleting "tests/Resources/Files/kueue-batch-notebook-user-specific-rolebinding.yaml": clusterrolebindings.rbac.authorization.k8s.io "kueue-batch-user-specific-rolebinding" not found
"Warning: Unable to delete kueue-batch-notebook-user-specific-rolebinding ClusterRoleBinding (may not exist)"
"Removing kueue-batch-user-role ClusterRole"
clusterrole.rbac.authorization.k8s.io "kueue-batch-user-role" deleted
"Removing codeflare-sdk-rbac-permissions"
clusterrolebinding.rbac.authorization.k8s.io "test-user-self-provisioner" deleted
clusterrolebinding.rbac.authorization.k8s.io "test-user-admin" deleted
clusterrolebinding.rbac.authorization.k8s.io "test-user-cluster-admin" deleted
clusterrole.rbac.authorization.k8s.io "test-user-kueue-admin" deleted
clusterrolebinding.rbac.authorization.k8s.io "test-user-kueue-admin" deleted
clusterrole.rbac.authorization.k8s.io "test-user-ray-admin" deleted
clusterrolebinding.rbac.authorization.k8s.io "test-user-ray-admin" deleted
Tests.Distributed Workloads.Test-Run-Distributed-Workloads-Tests :... | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Tests.Distributed Workloads                                           | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Output:  /workspace/ods-ci/ods_ci/test-output/ods-ci-2026-05-01-04-38-q6TAaRu5q5/output.xml
XUnit:   /workspace/ods-ci/ods_ci/test-output/ods-ci-2026-05-01-04-38-q6TAaRu5q5/xunit_test_result.xml
Log:     /workspace/ods-ci/ods_ci/test-output/ods-ci-2026-05-01-04-38-q6TAaRu5q5/log.html
Report:  /workspace/ods-ci/ods_ci/test-output/ods-ci-2026-05-01-04-38-q6TAaRu5q5/test_report.html
0
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configurations to enable Kueue-managed resource handling across multiple test suites.
  * Modified training iterations limit and metric reporting mechanism in training workflows.
  * Added version display and authentication setup steps to notebook initialization.

* **Chores**
  * Removed unused dependency from test requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->