### PR TITLE
Fix CEL pathChanged references in release-push pipelines

### DIFF
--- a/.tekton/odh-th06-cpu-torch210-py312-ci-on-release-push.yaml
+++ b/.tekton/odh-th06-cpu-torch210-py312-ci-on-release-push.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "release/odh-3.5-ea.1"
+      && ( "images/universal/training/th06-cpu-torch210-py312/**".pathChanged() || ".tekton/odh-th06-cpu-torch210-py312-ci-on-release-push.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-th06-cpu-torch210-py312-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th06-cpu-torch210-py312-ci-on-release-push
+  namespace: open-data-hub-tenant
+spec:
+  timeouts:
+    pipeline: 10h
+    tasks: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.5-ea1
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: images/universal/training/th06-cpu-torch210-py312
+  - name: build-platforms
+    value:
+    - linux-extra-fast/amd64
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-th06-cpu-torch210-py312-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-th06-cuda130-torch210-py312-ci-on-release-push.yaml
+++ b/.tekton/odh-th06-cuda130-torch210-py312-ci-on-release-push.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "release/odh-3.5-ea.1"
+      && ( "images/universal/training/th06-cuda130-torch210-py312/**".pathChanged() || ".tekton/odh-th06-cuda130-torch210-py312-ci-on-release-push.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-th06-cuda130-torch210-py312-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th06-cuda130-torch210-py312-ci-on-release-push
+  namespace: open-data-hub-tenant
+spec:
+  timeouts:
+    pipeline: 10h
+    tasks: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.5-ea1
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: images/universal/training/th06-cuda130-torch210-py312
+  - name: build-platforms
+    value:
+    - linux-extra-fast/amd64
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-th06-cuda130-torch210-py312-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-th06-rocm64-torch291-py312-release-push.yaml
+++ b/.tekton/odh-th06-rocm64-torch291-py312-release-push.yaml
@@ -1,0 +1,53 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release/odh-3.5-ea.1" && ( "images/universal/training/th06-rocm64-torch291-py312/**".pathChanged() || ".tekton/odh-th06-rocm64-torch291-py312-release-push.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-th06-rocm64-torch291-py312-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th06-rocm64-torch291-py312-ci-on-release-push
+  namespace: open-data-hub-tenant
+spec:
+  timeouts:
+    pipeline: 10h
+    tasks: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.5-ea1
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: images/universal/training/th06-rocm64-torch291-py312
+  - name: build-platforms
+    value:
+    - linux-extra-fast/amd64
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-th06-rocm64-torch291-py312-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-release-push.yaml
+++ b/.tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-release-push.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "release/odh-3.5-ea.1"
+      && ( "images/runtime/training/py312-cuda130-torch210-openmpi41/**".pathChanged()
+            || ".tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-release-push.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-training-cuda130-torch210-py312-openmpi41-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-training-cuda130-torch210-py312-openmpi41-ci-on-release-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-3.5-ea1
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: images/runtime/training/py312-cuda130-torch210-openmpi41
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-training-cuda130-torch210-py312-openmpi41-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary
- Fix CEL `.pathChanged()` in all 4 release-push tekton files to reference themselves instead of the regular push files
- Without this fix, modifying a release-push pipeline definition would not trigger a rebuild

## Files fixed
- `odh-th06-cpu-torch210-py312-ci-on-release-push.yaml`
- `odh-th06-cuda130-torch210-py312-ci-on-release-push.yaml`
- `odh-th06-rocm64-torch291-py312-release-push.yaml`
- `odh-training-cuda130-torch210-py312-openmpi41-ci-on-release-push.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)