### PR TITLE
fix: request GPU for failure scenario TrainJob pods

### DIFF
--- a/tests/trainer/resources/failure_scenarios.ipynb
+++ b/tests/trainer/resources/failure_scenarios.ipynb
@@ -145,6 +145,7 @@
     "                resources_per_node={\n",
     "                    \"cpu\": 4,\n",
     "                    \"memory\": \"16Gi\",\n",
+    "                    \"nvidia.com/gpu\": 1,\n",
     "                },\n",
     "            ),\n",
     "            runtime=runtime,\n",


### PR DESCRIPTION
## Summary
- Add `"nvidia.com/gpu": 1` to `resources_per_node` in the `run_failure_scenario()` helper in `failure_scenarios.ipynb`
- The test is already tagged `Gpu(support.NVIDIA)` but the TrainJob pods were not requesting GPU resources, causing them to land on CPU-only nodes
- On CPU nodes, `instructlab-training` and `unsloth` crash during CUDA init before reaching the intended validation code paths, producing GPU errors instead of the expected `FileNotFoundError` / `No config file found`

## Test plan
- [ ] Run `TestTrainingFailureScenarios` on a cluster with NVIDIA GPUs — all 5 failure scenarios should pass
- [ ] Verify failure scenario pods are scheduled on GPU nodes (`nvidia.com/gpu` in pod resource requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated GPU resource configuration in failure scenario testing to ensure comprehensive evaluation across resource environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->