### PR TITLE
feat: filter ClusterTrainingRuntime tests by Konflux ITS trigger image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,10 @@ with open(path, "w", encoding="utf-8") as f:
     json.dump(nb, f, indent=1, ensure_ascii=False)
 ```
 
+### Environment variables
+
+Declare env var constants and getter functions in `tests/common/support/environment.go`. Never use `os.Getenv` directly in test files — always go through a getter.
+
 ### Tags
 
 Tests in `tests/trainer/` **must** declare a tag — this is mandatory. Apply it as the first statement so tests are skipped early when `TEST_TIER` is set:

--- a/tests/common/support/environment.go
+++ b/tests/common/support/environment.go
@@ -64,6 +64,10 @@ const (
 
 	// Name of existing namespace to be used for test
 	testNamespaceNameEnvVar = "TEST_NAMESPACE_NAME"
+
+	// Name of the image that triggered the Konflux ITS pipeline run, used to
+	// filter which ClusterTrainingRuntimes are exercised in e2e tests.
+	TriggerImageName = "TRIGGER_IMAGE_NAME"
 )
 
 type ClusterType string
@@ -230,6 +234,10 @@ func GetPipTrustedHost() string {
 
 func GetTestNamespaceName() (string, bool) {
 	return os.LookupEnv(testNamespaceNameEnvVar)
+}
+
+func GetTriggerImageName() (string, bool) {
+	return os.LookupEnv(TriggerImageName)
 }
 
 func lookupEnvOrDefault(key, value string) string {

--- a/tests/trainer/cluster_training_runtimes_test.go
+++ b/tests/trainer/cluster_training_runtimes_test.go
@@ -177,9 +177,21 @@ func TestRunTrainJobWithDefaultClusterTrainingRuntimes(t *testing.T) {
 	Tags(t, Tier1)
 	test := With(t)
 
+	triggerImageName, triggerSet := GetTriggerImageName()
+	if triggerSet {
+		test.T().Logf("TRIGGER_IMAGE_NAME is set to '%s', only testing runtimes using this image", triggerImageName)
+	}
+
 	// Run one TrainJob per unique image to avoid redundant runs for CTRs that share the same image
 	tested := make(map[string]bool)
+	matchedTriggerRuntime := false
 	for _, runtime := range trainerutils.ExpectedRuntimes {
+		if triggerSet && runtime.Image != triggerImageName {
+			continue
+		}
+		if triggerSet {
+			matchedTriggerRuntime = true
+		}
 		if trainerutils.IsMPIRuntime(runtime.Name) {
 			test.T().Logf("Skipping MPI runtime '%s' (covered by TestMultiNodeOpenMPITrainJob)", runtime.Name)
 			continue
@@ -213,6 +225,13 @@ func TestRunTrainJobWithDefaultClusterTrainingRuntimes(t *testing.T) {
 			// Verify container images in the pods created by the TrainJob
 			verifyPodContainerImages(test, namespace, trainJob.Name)
 		}
+	}
+
+	if triggerSet && !matchedTriggerRuntime {
+		test.T().Fatalf("TRIGGER_IMAGE_NAME '%s' does not match any expected ClusterTrainingRuntime image", triggerImageName)
+	}
+	if triggerSet && len(tested) == 0 {
+		test.T().Skipf("TRIGGER_IMAGE_NAME '%s' matched only MPI runtimes; covered by TestMultiNodeOpenMPITrainJob", triggerImageName)
 	}
 
 	test.T().Log("All TrainJobs with expected ClusterTrainingRuntimes completed successfully !!!")


### PR DESCRIPTION
## Description

When Konflux Integration Test Scenarios (ITS) trigger a pipeline run for a specific image, only the ClusterTrainingRuntimes using that image need to be tested — running the full matrix is unnecessary and wastes resources.

This PR adds support for the `TRIGGER_IMAGE_NAME` environment variable in `TestRunTrainJobWithDefaultClusterTrainingRuntimes`. When set, the test filters runtimes to only exercise those matching the trigger image, and fails if no runtime matches (catching misconfiguration early). When unset, the test runs all runtimes as before.

Also adds the env var declaration to `environment.go` following the project convention, and documents the env var pattern in `AGENTS.md`.

## How Has This Been Tested?

- Verified via Konflux ITS pipeline run triggered by this PR ([test artifacts](https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com/odh-ci-artifacts/odh-pr-test-distributed-workloads-zmrpr/))
- Without `TRIGGER_IMAGE_NAME` set, all runtimes are tested (existing behavior preserved)

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on properly declaring and using environment variables in tests.

* **Tests**
  * Added support for filtering test execution by a specific trigger image via environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->