### PR TITLE
fix: add aarch64 to CUDA MPI RPM prefetch lockfile

### DIFF
--- a/images/runtime/training/py312-cuda130-torch210-openmpi41/rpms.in.yaml
+++ b/images/runtime/training/py312-cuda130-torch210-openmpi41/rpms.in.yaml
@@ -7,6 +7,7 @@ packages:
 
 arches:
   - x86_64
+  - aarch64
 
 context:
   containerfile: Dockerfile.konflux

--- a/images/runtime/training/py312-cuda130-torch210-openmpi41/rpms.lock.yaml
+++ b/images/runtime/training/py312-cuda130-torch210-openmpi41/rpms.lock.yaml
@@ -27,3 +27,28 @@ arches:
     sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
   source: []
   module_metadata: []
+- arch: aarch64
+  packages:
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssh-8.7p1-45.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 456820
+    checksum: sha256:8a8eed20672cdd7dfa7cabb3a6d0db93a45e0f78d60f8194c8723cc96fb28cdc
+    name: openssh
+    evr: 8.7p1-45.el9_6.2
+    sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 698879
+    checksum: sha256:60e1843ee481b3a1a29dd84fb1b83af57748fd31146a132f70ba238134f12b98
+    name: openssh-clients
+    evr: 8.7p1-45.el9_6.2
+    sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssh-server-8.7p1-45.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 446203
+    checksum: sha256:361ca6dcf510920a65422dc38f4ac95089535606f0521b1e44e5b61a98d9851e
+    name: openssh-server
+    evr: 8.7p1-45.el9_6.2
+    sourcerpm: openssh-8.7p1-45.el9_6.2.src.rpm
+  source: []
+  module_metadata: []


### PR DESCRIPTION
## Summary
- Add aarch64 arch to CUDA MPI `rpms.in.yaml` and regenerate lockfile with both x86_64 and aarch64 packages
- Lockfile generated from EUS repos using base image to ensure matching z-stream versions

## Test plan
- [ ] Verify CUDA MPI image Konflux hermetic build succeeds for both x86_64 and aarch64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Extended runtime environment support to include ARM64 (aarch64) architecture, in addition to existing x86_64 support, for the Python 3.12 + CUDA 13.0 + PyTorch 2.1.0 + OpenMPI 4.1 training runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->