### PR TITLE
fix: use prefetched pip packages in MPI Dockerfile.konflux

### DIFF
--- a/images/runtime/training/py312-cuda130-torch210-openmpi41/Dockerfile.konflux
+++ b/images/runtime/training/py312-cuda130-torch210-openmpi41/Dockerfile.konflux
@@ -63,6 +63,7 @@ WORKDIR /opt/app-root/bin
 COPY requirements.txt ./
 
 RUN uv pip install --no-cache \
+        --no-index --find-links "${PIP_FIND_LINKS}" \
         --python /opt/app-root/bin/python3.12 \
         -r requirements.txt && \
     rm -f ./requirements.txt && \

--- a/images/runtime/training/py312-rocm64-torch29-openmpi41/Dockerfile.konflux
+++ b/images/runtime/training/py312-rocm64-torch29-openmpi41/Dockerfile.konflux
@@ -69,8 +69,7 @@ WORKDIR /opt/app-root/bin
 COPY requirements.txt ./
 
 RUN uv pip install --no-cache \
-    --index-url=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/rocm6.4-ubi9-test/simple/ \
-    --extra-index-url=https://pypi.org/simple \
+    --no-index --find-links "${PIP_FIND_LINKS}" \
     --python /opt/app-root/bin/python3.12 \
     -r requirements.txt && \
     rm -f ./requirements.txt && \


### PR DESCRIPTION
## Summary
- MPI hermetic builds fail at `uv pip install` because `uv` tries to reach remote PyPI indexes which are blocked in network-isolated builds
- Add `--no-index --find-links "${PIP_FIND_LINKS}"` to `uv pip install` in both CUDA and ROCm `Dockerfile.konflux`, matching the pattern used by the universal training image

## Test plan
- [ ] Verify CUDA MPI image Konflux hermetic build passes `uv pip install` step
- [ ] Verify ROCm MPI image Konflux hermetic build passes `uv pip install` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configurations to use local package dependencies instead of remote PyPI indexes for Python training runtime images, improving build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->