### PR TITLE
E2E: Remove torchvision and pillow from CUDA/ROCm/Cpu test requirements

### DIFF
--- a/tests/trainer/resources/requirements-cpu.txt
+++ b/tests/trainer/resources/requirements-cpu.txt
@@ -4,4 +4,3 @@
 
 minio==7.2.20
 torchvision==0.25.0+cpu  # no-deps
-pillow==11.0.0  # no-deps

--- a/tests/trainer/resources/requirements-cuda.txt
+++ b/tests/trainer/resources/requirements-cuda.txt
@@ -1,7 +1,2 @@
 # Install only packages which are not present in base image
-# Use "# no-deps" marker for packages that should be installed without dependencies
---extra-index-url https://download.pytorch.org/whl/cu130
-
 minio==7.2.20
-torchvision==0.25.0+cu130  # no-deps
-pillow==11.0.0  # no-deps

--- a/tests/trainer/resources/requirements-rocm.txt
+++ b/tests/trainer/resources/requirements-rocm.txt
@@ -1,8 +1,2 @@
-# Uses PyTorch ROCm wheel index for compatible packages
 # Install only packages which are not present in base image
-# Use "# no-deps" marker for packages that should be installed without dependencies
---extra-index-url https://download.pytorch.org/whl/rocm6.4
-
 minio==7.2.20
-torchvision==0.24.1+rocm6.4  # no-deps
-pillow==11.0.0  # no-deps

--- a/tests/trainer/resources/requirements.txt
+++ b/tests/trainer/resources/requirements.txt
@@ -1,6 +1,0 @@
-# Install only packages which are not present in base image
-# Use "# no-deps" marker for packages that should be installed without dependencies
-
-minio==7.2.13
-torchvision==0.23.0  # no-deps
-pillow==11.0.0  # no-deps


### PR DESCRIPTION
Remove torchvision and pillow from CUDA/ROCm/Cpu test requirements

## Description
torchvision and pillow are already present in the CUDA and ROCm base images (th06-cuda130-torch210-py312 and th06-rocm64-torch291-py312). 
For CPU, keep torchvision (not in base image) but bump to 0.25.0+cpu to match torch 2.10.0, and drop pillow (already in base image).
Removed resources/requirements.txt as this is not used by any test.

## How Has This Been Tested?
Tested locally by running the test for each - CUDA/ROCm/Cpu

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development testing dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->