### PR TITLE
fix: skip tests related to RHOAIENG-61966

### DIFF
--- a/tests/trainer/cluster_training_runtimes_test.go
+++ b/tests/trainer/cluster_training_runtimes_test.go
@@ -117,6 +117,7 @@ func TestDefaultClusterTrainingRuntimes(t *testing.T) {
 }
 
 func TestOpenMPICudaClusterTrainingRuntime(t *testing.T) {
+	t.Skip("Skip due to issue RHOAIENG-61966")
 	Tags(t, Smoke)
 	test := With(t)
 

--- a/tests/trainer/trainer_mpi_test.go
+++ b/tests/trainer/trainer_mpi_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestMultiNodeOpenMPITrainJob(t *testing.T) {
+	t.Skip("Skip due to issue RHOAIENG-61966")
 	Tags(t, KftoCuda, MultiNodeGpu(2, NVIDIA))
 	test := With(t)
 

--- a/tests/trainer/trainer_openmpi_kueue_integration_test.go
+++ b/tests/trainer/trainer_openmpi_kueue_integration_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestOpenMPICudaTrainJobKueueIntegration(t *testing.T) {
+	t.Skip("Skip due to issue RHOAIENG-61966")
 	Tags(t, KftoCuda, MultiNodeGpu(2, NVIDIA))
 	test := With(t)
 	SetupKueue(test, initialKueueState, TrainJobFramework)
@@ -134,6 +135,7 @@ func TestOpenMPICudaTrainJobKueueIntegration(t *testing.T) {
 }
 
 func TestOpenMPICudaTrainJobKueueWorkloadDeactivateReactivate(t *testing.T) {
+	t.Skip("Skip due to issue RHOAIENG-61966")
 	Tags(t, KftoCuda, MultiNodeGpu(2, NVIDIA))
 	test := With(t)
 	SetupKueue(test, initialKueueState, TrainJobFramework)


### PR DESCRIPTION
Temporarily skip the TestOpenMPICudaClusterTrainingRuntime, TestMultiNodeOpenMPITrainJob, and TestOpenMPICudaTrainJobKueueIntegration tests due to an identified issue (RHOAIENG-61966) that affects their execution.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
