### PR TITLE
fix: use node-local Triton cache to avoid NFS stale file handle

### DIFF
--- a/tests/trainer/resources/lora.ipynb
+++ b/tests/trainer/resources/lora.ipynb
@@ -446,7 +446,7 @@
     ")\n",
     "\n",
     "cache_root = \"/opt/app-root/src/.cache/huggingface\"\n",
-    "triton_cache = \"/opt/app-root/src/.triton\"\n",
+    "triton_cache = \"/tmp/.triton\"\n",
     "\n",
     "job_name = client.train(\n",
     "    trainer=TrainingHubTrainer(\n",

--- a/tests/trainer/resources/osft.ipynb
+++ b/tests/trainer/resources/osft.ipynb
@@ -374,7 +374,7 @@
     ")\n",
     "\n",
     "cache_root = \"/opt/app-root/src/.cache/huggingface\"\n",
-    "triton_cache = \"/opt/app-root/src/.triton\"\n",
+    "triton_cache = \"/tmp/.triton\"\n",
     "\n",
     "job_name = client.train(\n",
     "    trainer=TrainingHubTrainer(\n",

--- a/tests/trainer/resources/sft.ipynb
+++ b/tests/trainer/resources/sft.ipynb
@@ -460,7 +460,7 @@
     ")\n",
     "\n",
     "cache_root = \"/opt/app-root/src/.cache/huggingface\"\n",
-    "triton_cache = \"/opt/app-root/src/.triton\"\n",
+    "triton_cache = \"/tmp/.triton\"\n",
     "\n",
     "job_name = client.train(\n",
     "    trainer=TrainingHubTrainer(\n",

--- a/tests/trainer/resources/torchrun_failure.ipynb
+++ b/tests/trainer/resources/torchrun_failure.ipynb
@@ -318,7 +318,7 @@
     "}\n",
     "\n",
     "cache_root = \"/opt/app-root/src/.cache/huggingface\"\n",
-    "triton_cache = \"/opt/app-root/src/.triton\"\n",
+    "triton_cache = \"/tmp/.triton\"\n",
     "\n",
     "job_name = client.train(\n",
     "    trainer=TrainingHubTrainer(\n",


### PR DESCRIPTION
## Summary
- Move `TRITON_CACHE_DIR` from `/opt/app-root/src/.triton` (shared NFS PVC) to `/tmp/.triton` (container-local) in all SDK test notebooks (`lora.ipynb`, `osft.ipynb`, `sft.ipynb`, `torchrun_failure.ipynb`)
- Fixes intermittent `OSError: [Errno 116] Stale file handle` in multi-node training when concurrent pods compile Triton kernels on shared NFS

## Root Cause
Multi-node training pods share the same NFS-backed PVC at `/opt/app-root/src`. When both nodes compile Triton GPU kernels concurrently, one node writes cache metadata files while the other reads them — resulting in NFS stale file handles. This caused flaky `BackoffLimitExceeded` failures in `TestLoraTrainingHubMultiNodeMultiGPU` and similar multi-node tests.

## Fix
`/tmp` is container-local overlay storage, so each pod gets its own independent Triton cache with no cross-node contention. No additional volumes needed.

## Test plan
- [ ] `TestLoraTrainingHubMultiNodeMultiGPU` passes without stale file handle crashes
- [ ] `TestLoraTrainingHubSingleNodeSingleGPU` still passes (single-node unaffected)
- [ ] `TestOsftTrainingHubMultiNodeMultiGPU` passes
- [ ] `TestSftTrainingHubMultiNodeMultiGPU` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated training job cache directory configurations to use a new storage location across multiple training notebooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->