### PR TITLE
feat: add Slack notification workflow for jira-autofix PRs

### DIFF
--- a/.github/workflows/notify-autofix-prs.yml
+++ b/.github/workflows/notify-autofix-prs.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     if: >-
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.user.login == 'jira-autofix-bot'
+      github.event.pull_request.user.login == 'jira-autofix[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Post new autofix PR to Slack
@@ -63,7 +63,7 @@ jobs:
 
           prs=$(gh pr list \
             --repo "$GITHUB_REPOSITORY" \
-            --author jira-autofix-bot \
+            --author app/jira-autofix \
             --state open \
             --json number,title,url,createdAt \
             --jq '.[] | "\(.number)\t\(.title)\t\(.url)\t\(.createdAt)"')
@@ -82,13 +82,17 @@ jobs:
             else
               age="${days} days old"
             fi
-            pr_lines="${pr_lines}• <${url}|#${number}> — ${title} (${age})\n"
+            pr_lines+="• <${url}|#${number}> — ${title} (${age})"$'\n'
             count=$((count + 1))
           done <<< "$prs"
 
+          header=":robot_face: jira-autofix: ${count} open PR(s) awaiting review"
+          footer="cc <!subteam^S07LB79MA1M>"
           payload=$(jq -n \
-            --arg body ":robot_face: jira-autofix: ${count} open PR(s) awaiting review\n\n${pr_lines}\ncc <!subteam^S07LB79MA1M>" \
-            '{text: $body}')
+            --arg header "$header" \
+            --arg prs "$pr_lines" \
+            --arg footer "$footer" \
+            '{text: ($header + "\n\n" + $prs + "\n" + $footer)}')
 
           curl -sf -X POST -H 'Content-Type: application/json' \
             -d "$payload" \


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that posts to `#training_kubeflow_dev_support` via Slack webhook when `jira-autofix[bot]` opens a PR (instant notification) and as a daily digest of all open autofix PRs (weekdays 9:03 UTC)
- Tags `@openshift-ai-training-kubeflow` team DL in notifications
- Requires `SLACK_AUTOFIX_WEBHOOK_URL` repository secret to be configured

## Context
Team discussed in [Slack thread](https://redhat-internal.slack.com/archives/C07H73Y9623/p1778575830462719) that autofix bot PRs go unnoticed since only Jira contributors get email notifications. Agreed on daily digest + instant notification to the dev support channel.

Supersedes #845

## Test plan
- [x] Trigger workflow manually via Actions > "Notify open jira-autofix PRs" > Run workflow
- [x] Verify Slack message appears in `#training_kubeflow_dev_support` with correct formatting
- [x] Verify no message is sent when there are zero open autofix PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to correctly target the automated bot account for pull request notifications.
  * Refactored Slack notification message construction for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->