### PR TITLE
fix: bump test image to Go 1.25 to match go.mod

### DIFF
--- a/images/tests/Dockerfile
+++ b/images/tests/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Go image as a base image
-FROM golang:1.24
+FROM golang:1.25
 
 ENV KUBECONFIG=/distributed-workloads/tests/.kube/config
 


### PR DESCRIPTION
## Summary
- `go.mod` was bumped to `go 1.25.0` but the test image Dockerfile (`images/tests/Dockerfile`) still used `golang:1.24`, causing the [CI build to fail](https://github.com/opendatahub-io/distributed-workloads/actions/runs/25846171022/job/75941806607) with `go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`
- Updates the base image from `golang:1.24` to `golang:1.25`

## Test plan
- [ ] CI `build-and-push-test-images` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use Go version 1.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->