### PR TITLE
fix: wait for progression capture before suspending TrainJob

### DIFF
--- a/tests/trainer/resources/rhai_features.ipynb
+++ b/tests/trainer/resources/rhai_features.ipynb
@@ -417,7 +417,7 @@
     "trainer_kwargs[\"enable_progression_tracking\"] = enable_progression\n",
     "if enable_progression:\n",
     "    trainer_kwargs[\"metrics_port\"] = 28080\n",
-    "    trainer_kwargs[\"metrics_poll_interval_seconds\"] = 8\n",
+    "    trainer_kwargs[\"metrics_poll_interval_seconds\"] = 5\n",
     "\n",
     "# Add checkpointing if enabled\n",
     "if enable_checkpoint:\n",

--- a/tests/trainer/sdk_tests/rhai_features_tests.go
+++ b/tests/trainer/sdk_tests/rhai_features_tests.go
@@ -536,9 +536,9 @@ func runRhaiFeaturesTestWithConfig(t *testing.T, config RhaiFeatureConfig) {
 			"Expected metrics-port annotation to be '28080'")
 		test.T().Log("metrics-port annotation is '28080'")
 
-		test.Expect(annotations[annotationMetricsPollInterval]).To(Equal("8"),
-			"Expected metrics-poll-interval annotation to be '8'")
-		test.T().Log("metrics-poll-interval annotation is '8'")
+		test.Expect(annotations[annotationMetricsPollInterval]).To(Equal("5"),
+			"Expected metrics-poll-interval annotation to be '5'")
+		test.T().Log("metrics-poll-interval annotation is '5'")
 
 		// Verify training completed successfully by checking pod termination message.
 		// The termination message is written by the training process itself and is the authoritative source.
@@ -764,6 +764,19 @@ func verifyCheckpoints(test Test, namespace, trainJobName, checkpointDir string,
 	}, TestTimeoutLong, 5*time.Second).Should(BeTrue(), "Training should complete at least 2 epochs before suspension")
 	test.T().Log("At least 2 epochs completed - ready to suspend")
 
+	// Wait for operator to poll metrics and capture progression before suspending.
+	// The operator polls the pod's HTTP metrics endpoint at the configured interval.
+	// We must wait for at least one successful poll while pods are still alive,
+	// otherwise suspending kills the pods before progress is ever captured.
+	if progressionEnabled {
+		test.T().Log("Waiting for progression tracking to be captured by operator...")
+		test.Eventually(func() int {
+			return getProgressPercentage(test, namespace, trainJobName)
+		}, TestTimeoutMedium, 1*time.Second).Should(BeNumerically(">", 0),
+			"Operator should capture progression while training pods are still running")
+		test.T().Log("Progression captured by operator")
+	}
+
 	// Verify cloud checkpoint upload is working (only for cloud storage mode, not PVC)
 	// This catches SDK monkey-patch failures early - if save_strategy override didn't apply,
 	// no checkpoints are saved and no uploads happen
@@ -849,20 +862,14 @@ func verifyCheckpoints(test Test, namespace, trainJobName, checkpointDir string,
 	test.Expect(TrainJobConditionSuspended(trainJob)).To(Equal(metav1.ConditionTrue), "TrainJob should be in suspended state")
 	test.T().Log("TrainJob is suspended")
 
-	// Step 5: Store progress before resume (only when progression tracking is enabled)
+	// Step 5: Read progress state for resume comparison
 	var preSuspendProgress int
 	var preSuspendEpoch float64
 	if progressionEnabled {
-		// Wait for operator to poll metrics and update TrainJob annotations.
-		// This ensures progress is recorded before suspending the job.
-		test.T().Log("Step 5: Waiting for progress to be tracked in TrainJob...")
-		test.Eventually(func() int {
-			return getProgressPercentage(test, namespace, trainJobName)
-		}, TestTimeoutMedium, 5*time.Second).Should(BeNumerically(">", 0), "Progress should be tracked before suspension")
-
+		test.T().Log("Step 5: Reading progression state after suspend...")
 		preSuspendProgress = getProgressPercentage(test, namespace, trainJobName)
 		preSuspendEpoch = getCurrentEpoch(test, namespace, trainJobName)
-		test.T().Logf("Pre-suspend state: epoch=%.2f, progress=%d%%", preSuspendEpoch, preSuspendProgress)
+		test.T().Logf("Pre-resume state: epoch=%.2f, progress=%d%%", preSuspendEpoch, preSuspendProgress)
 	}
 
 	// Step 6: Resume the TrainJob


### PR DESCRIPTION
## Summary

- Wait for the operator to capture progression data while training pods are still alive before suspending
- Previously the test suspended first, then waited for progression — but pods were already dead and the operator could no longer poll the metrics endpoint
- Reduce metrics poll interval from 8s to 5s (SDK minimum) to maximize capture window for fast training jobs

## Root cause

`TestRhaiFeaturesCuda` has been failing for 8 consecutive nightly builds. The test suspends the TrainJob after 2 epochs (~13s of GPU training), then waits up to 600s for progression > 0. But by that point, pods are terminated and the operator can no longer poll the HTTP metrics endpoint (port 28080). With an 8-second poll interval and only ~13 seconds of training, the operator often missed capturing any progression data before the pods were killed.

## Changes

1. **Wait for progression before suspend** (`rhai_features_tests.go`): Added an `Eventually()` poll that waits for `progressPercentage > 0` while pods are still running, before triggering the suspend
2. **Reduce poll interval** (`rhai_features.ipynb`): Changed `metrics_poll_interval_seconds` from 8 to 5 (SDK minimum) so the operator polls more frequently during short training runs
3. **Simplify Step 5**: Post-suspend step now reads progression state directly instead of polling with a 600s timeout — progression is already guaranteed captured before suspend

## Test plan

- [x] `go vet` and `go build` pass
- [x] Tested on RHOAI 3.4 cluster with A100 GPUs — suspend/resume flow passes, progression captured successfully before suspend (epoch=1.20, progress=24%)
- [ ] Nightly CI validation on RHOAI 3.5 with latest operator (includes opendatahub-io/trainer#153 fix for 100% finalization)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated progression tracking configuration tests to reflect metrics polling interval of 5 seconds
  * Enhanced checkpoint suspend/resume test flow for improved progress tracking verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->