### PR TITLE
fix: replace TrainJob suspended condition check with pod phase assert…

### DIFF
--- a/tests/trainer/trainer_kueue_integration_test.go
+++ b/tests/trainer/trainer_kueue_integration_test.go
@@ -24,6 +24,7 @@ import (
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kueuev1beta2 "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 
@@ -190,11 +191,19 @@ func TestKueueWorkloadPreemptionSuspendsTrainJob(t *testing.T) {
 	workload := GetKueueWorkloads(test, namespace)[0]
 	test.T().Logf("Workload '%s' is admitted", workload.Name)
 
-	// Verify TrainJob is running
-	test.Eventually(TrainJob(test, namespace, createdTrainJob.Name), TestTimeoutShort).Should(
-		WithTransform(TrainJobConditionSuspended, Equal(metav1.ConditionFalse)),
+	// Verify TrainJob is running by checking training node pods are in Running phase
+	// (The Suspended condition may not be set immediately due to Kueue admission timing)
+	test.T().Log("Verifying TrainJob pods are running...")
+
+	test.Eventually(Pods(test, namespace, metav1.ListOptions{
+		LabelSelector: "jobset.sigs.k8s.io/jobset-name=" + createdTrainJob.Name,
+	}), TestTimeoutShort).Should(
+		And(
+			HaveLen(1),
+			ContainElement(WithTransform(podPhase, Equal(corev1.PodRunning))),
+		),
 	)
-	test.T().Logf("TrainJob '%s' is running", createdTrainJob.Name)
+	test.T().Logf("TrainJob '%s' pods are running", createdTrainJob.Name)
 
 	// Preempt the workload
 	test.T().Logf("User is preempting workload '%s' now ...", workload.Name)


### PR DESCRIPTION
…ion in Kueue preemption test

TrainJobConditionSuspended returns Unknown when Kueue admits workloads faster than the operator can reconcile status (suspends → unsuspends before condition is written). Verify pods are Running instead.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test for workload preemption: verification now waits for exactly one training pod to reach Running (selected by jobset label) before proceeding, yielding more reliable validation of preemption and suspension behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->