### PR TITLE
Update urllib3 to 2.7.0 in universal training images

### DIFF
--- a/images/universal/training/th06-cpu-torch210-py312/requirements.txt
+++ b/images/universal/training/th06-cpu-torch210-py312/requirements.txt
@@ -592,7 +592,7 @@ typing-inspection==0.4.2
     #   pydantic
 tzdata==2026.1
     # via pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   docker

--- a/images/universal/training/th06-cuda130-torch210-py312/requirements.txt
+++ b/images/universal/training/th06-cuda130-torch210-py312/requirements.txt
@@ -731,7 +731,7 @@ unsloth==2026.3.3
     #   training-hub
 unsloth-zoo==2026.4.7
     # via unsloth
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   docker

--- a/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
+++ b/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
@@ -708,7 +708,7 @@ unsloth==2026.3.3
     #   training-hub
 unsloth-zoo==2026.4.3
     # via unsloth
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   docker


### PR DESCRIPTION
## Summary
- Upgrades urllib3 from 2.6.3 to 2.7.0 in universal training images (requirements.txt)
- Fixes CVE-2026-44432: Denial of Service due to excessive HTTP response decompression
- Companion to #856 which updated the runtime training images

## Test plan
- [ ] Verify universal training images build successfully
- [ ] Run smoke tests against updated images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated urllib3 package to version 2.7.0 across multiple training environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->