### PR TITLE
Use larger build platform for universal training images

### DIFF
--- a/.tekton/odh-th06-cpu-torch210-py312-ci-on-pull-request.yaml
+++ b/.tekton/odh-th06-cpu-torch210-py312-ci-on-pull-request.yaml
@@ -40,6 +40,15 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-cpu-torch210-py312-ci-on-pull-request.yaml
+++ b/.tekton/odh-th06-cpu-torch210-py312-ci-on-pull-request.yaml
@@ -49,6 +49,14 @@ spec:
           memory: 4Gi
         limits:
           memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-cpu-torch210-py312-ci-on-pull-request.yaml
+++ b/.tekton/odh-th06-cpu-torch210-py312-ci-on-pull-request.yaml
@@ -39,7 +39,7 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-cpu-torch210-py312-ci-on-push.yaml
+++ b/.tekton/odh-th06-cpu-torch210-py312-ci-on-push.yaml
@@ -45,6 +45,14 @@ spec:
           memory: 4Gi
         limits:
           memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-cpu-torch210-py312-ci-on-push.yaml
+++ b/.tekton/odh-th06-cpu-torch210-py312-ci-on-push.yaml
@@ -36,6 +36,15 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-cpu-torch210-py312-ci-on-push.yaml
+++ b/.tekton/odh-th06-cpu-torch210-py312-ci-on-push.yaml
@@ -35,7 +35,7 @@ spec:
     value: images/universal/training/th06-cpu-torch210-py312
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-cuda130-torch210-py312-ci-on-pull-request.yaml
+++ b/.tekton/odh-th06-cuda130-torch210-py312-ci-on-pull-request.yaml
@@ -40,6 +40,15 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-cuda130-torch210-py312-ci-on-pull-request.yaml
+++ b/.tekton/odh-th06-cuda130-torch210-py312-ci-on-pull-request.yaml
@@ -49,6 +49,14 @@ spec:
           memory: 4Gi
         limits:
           memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-cuda130-torch210-py312-ci-on-pull-request.yaml
+++ b/.tekton/odh-th06-cuda130-torch210-py312-ci-on-pull-request.yaml
@@ -39,7 +39,7 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-cuda130-torch210-py312-ci-on-push.yaml
+++ b/.tekton/odh-th06-cuda130-torch210-py312-ci-on-push.yaml
@@ -45,6 +45,14 @@ spec:
           memory: 4Gi
         limits:
           memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-cuda130-torch210-py312-ci-on-push.yaml
+++ b/.tekton/odh-th06-cuda130-torch210-py312-ci-on-push.yaml
@@ -36,6 +36,15 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-cuda130-torch210-py312-ci-on-push.yaml
+++ b/.tekton/odh-th06-cuda130-torch210-py312-ci-on-push.yaml
@@ -35,7 +35,7 @@ spec:
     value: images/universal/training/th06-cuda130-torch210-py312
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-rocm64-torch291-py312-pull-request.yaml
+++ b/.tekton/odh-th06-rocm64-torch291-py312-pull-request.yaml
@@ -41,6 +41,15 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-rocm64-torch291-py312-pull-request.yaml
+++ b/.tekton/odh-th06-rocm64-torch291-py312-pull-request.yaml
@@ -40,7 +40,7 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-rocm64-torch291-py312-pull-request.yaml
+++ b/.tekton/odh-th06-rocm64-torch291-py312-pull-request.yaml
@@ -50,6 +50,14 @@ spec:
           memory: 4Gi
         limits:
           memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-rocm64-torch291-py312-push.yaml
+++ b/.tekton/odh-th06-rocm64-torch291-py312-push.yaml
@@ -34,7 +34,7 @@ spec:
     value: images/universal/training/th06-rocm64-torch291-py312
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-rocm64-torch291-py312-push.yaml
+++ b/.tekton/odh-th06-rocm64-torch291-py312-push.yaml
@@ -35,6 +35,15 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-th06-rocm64-torch291-py312-push.yaml
+++ b/.tekton/odh-th06-rocm64-torch291-py312-push.yaml
@@ -44,6 +44,14 @@ spec:
           memory: 4Gi
         limits:
           memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Switch universal training image builds (CPU, CUDA, ROCm) from `linux-extra-fast/amd64` to `linux-d160-m8xlarge/amd64`
- Fixes OOMKilled failures during build and clair-scan steps for these large images

## Test plan
- [ ] Verify all three universal training images build successfully
- [ ] Verify clair-scan completes without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)