### PR TITLE
Add CI workflow and Makefile target for unit tests

### DIFF
--- a/.github/workflows/go-unit-test.yml
+++ b/.github/workflows/go-unit-test.yml
@@ -1,0 +1,28 @@
+name: Go unit tests
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.go'
+      - '**go.mod'
+      - '**go.sum'
+  pull_request:
+    paths:
+      - '**.go'
+      - '**go.mod'
+      - '**go.sum'
+jobs:
+  unit-test:
+    name: Go unit tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: './go.mod'
+    - name: Unit tests
+      run: go test ./tests/common/support/...

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ build-osu-benchmark-cuda-image:
 push-osu-benchmark-cuda-image:
 	podman push "${OSU_BENCHMARK_CUDA_IMAGE}"
 
+.PHONY: unit-test
+unit-test: ## Run unit tests for support packages.
+	go test ./tests/common/support/...
+
 .PHONY: precommit
 precommit:
 	pre-commit run --all-files


### PR DESCRIPTION
## Description
- Add `.github/workflows/go-unit-test.yml` that runs `go test ./tests/common/support/...` on PRs and pushes to main 
- Add `make unit-test` Makefile target for local convenience
 
 ## Why
 The support package has 13 unit test files that validate shared helpers (fake clients,  resource builders, environment getters, etc.).  A regression here could silently break assumptions across all e2e test suites.

 
## How Has This Been Tested?
- [x] `go test ./tests/common/support/...` passed locally 
  - [ ] Verify workflow triggers on a PR that touches Go files

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated unit testing workflow triggered on Go file changes.
  * Added make target for running unit tests for support packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->