### PR TITLE
Add golangci-lint config and lint documentation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+run:
+  allow-parallel-runners: true
+
+linters:
+  default: none
+  enable:
+    - govet
+    - unused
+    - ineffassign
+
+issues:
+  max-same-issues: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,30 @@ go test -run TestRhaiS3FsdpSharedStateCheckpointingCuda -v -timeout 60m ./tests/
 
 See the [Common environment variables](README.md#common-environment-variables) section in `README.md` for the full env var reference.
 
+## Lint/format & pre-commit
+
+```bash
+make golangci-lint                                # Run golangci-lint project-wide
+go vet ./...                                      # Vet all Go code
+make verify-imports                               # Verify import ordering
+make precommit                                    # Run all pre-commit hooks
+```
+
+### Targeted lint/format
+
+For quick feedback on specific files instead of running project-wide:
+
+```bash
+# Go
+make golangci-lint LINT_PKG=./tests/common/support/...    # Lint a single Go package
+go vet ./tests/common/support/...                         # Vet a single Go package
+gofmt -w path/to/file.go                                  # Format a single Go file
+
+# Python
+pre-commit run --files path/to/file.py                    # Run all hooks on a single file
+
+```
+
 ## Writing Tests
 
 ### Namespace isolation

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,17 @@ push-osu-benchmark-cuda-image:
 .PHONY: unit-test
 unit-test: ## Run unit tests for support packages.
 	go test ./tests/common/support/...
+GOLANGCI_LINT_VERSION ?= v2.12.1
+LINT_PKG ?= ./...
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+
+.PHONY: golangci-lint-install
+golangci-lint-install: $(LOCALBIN) ## Download golangci-lint locally.
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+.PHONY: golangci-lint
+golangci-lint: golangci-lint-install ## Run golangci-lint on the codebase.
+	$(GOLANGCI_LINT) run --timeout 5m $(LINT_PKG)
 
 .PHONY: precommit
 precommit:

--- a/tests/common/notebook.go
+++ b/tests/common/notebook.go
@@ -40,13 +40,6 @@ const (
 //go:embed resources/*
 var files embed.FS
 
-func readFile(t Test, fileName string) []byte {
-	t.T().Helper()
-	file, err := files.ReadFile(fileName)
-	t.Expect(err).NotTo(gomega.HaveOccurred())
-	return file
-}
-
 var (
 	SmallContainerResources = ContainerResources{
 		Limits:   ResourceConfig{CPU: "2", Memory: "3Gi"},

--- a/tests/kfto/support.go
+++ b/tests/kfto/support.go
@@ -20,7 +20,6 @@ import (
 	"embed"
 	"time"
 
-	gonanoid "github.com/matoous/go-nanoid/v2"
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	prometheusapiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -75,10 +74,4 @@ func withEnvVarName(name string) compare[corev1.EnvVar] {
 	return func(e1, e2 corev1.EnvVar) bool {
 		return e1.Name == name
 	}
-}
-
-// Adds a unique suffix to the provided string
-func uniqueSuffix(prefix string) string {
-	suffix := gonanoid.MustGenerate("1234567890abcdef", 4)
-	return prefix + "-" + suffix
 }

--- a/tests/odh/support.go
+++ b/tests/odh/support.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"time"
 
-	gonanoid "github.com/matoous/go-nanoid/v2"
 	gomega "github.com/onsi/gomega"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
@@ -232,12 +231,6 @@ func ensureNotebookServiceAccount(test support.Test, namespace string) {
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		test.T().Fatalf("Failed to create ServiceAccount %s/%s: %v", namespace, saName, err)
 	}
-}
-
-// Adds a unique suffix to the provided string
-func uniqueSuffix(prefix string) string {
-	suffix := gonanoid.MustGenerate("1234567890abcdef", 4)
-	return prefix + "-" + suffix
 }
 
 // TryMonitorRayJob attempts to monitor the Ray job via the external dashboard.


### PR DESCRIPTION
## Summary
- Add `.golangci.yml` with `govet`, `unused`, and `ineffassign` linters (v2 config format)
- Add `make golangci-lint` and `make golangci-lint-install` Makefile targets (pinned to v2.12.1)
- Support targeted linting via `LINT_PKG` variable (e.g., `make golangci-lint LINT_PKG=./tests/common/support/...`)
- Document lint/format commands (Go and Python) in AGENTS.md
- Remove 3 unused functions flagged by the linter: `readFile`, `uniqueSuffix` (x2)

## Why
The repo had `go vet` in CI and `openshift-goimports` in Makefile, but no `.golangci.yml` and no single-file lint commands documented. This adds a lightweight linter config matching the `opendatahub-io/training-operator` pattern, focused on correctness checks appropriate for a test repo.

## Test plan
- [x] `make golangci-lint` passes with 0 issues
- [x] `make golangci-lint LINT_PKG=./tests/common/support/...` works for targeted linting
- [x] `go vet ./...` passes
- [x] `make verify-imports` passes
- [x] `go test ./tests/common/support/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added developer guide for running linting and code formatting commands.

* **Chores**
  * Updated linting configuration with streamlined tooling setup.
  * Added build targets for running linting checks.
  * Removed unused internal dependencies.
  * Simplified internal test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->