### PR TITLE
Add CVE fix guidance for private AIPCC PyPI index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,3 +155,7 @@ Tests in `tests/trainer/` **must** declare a tag — this is mandatory. Apply it
 | `MultiNode(n)` | Requires n worker nodes |
 | `MultiNodeGpu(n, accelerator)` | Requires n nodes each with at least one GPU |
 | `MultiNodeMultiGpu(n, accelerator, gpus)` | Requires n nodes each with at least gpus GPUs |
+
+## CVE Fixes — Python dependency updates
+
+See [images/universal/training/README.md](images/universal/training/README.md#cve-fixes--python-dependency-updates) for instructions on updating Python dependencies in training images. Key point: dependencies come from a private AIPCC PyPI index, not public PyPI — always query the index for available versions before pinning.

--- a/images/universal/training/README.md
+++ b/images/universal/training/README.md
@@ -85,6 +85,19 @@ The `entrypoint-universal.sh` script handles mode detection:
 
 ---
 
+## CVE Fixes — Python dependency updates
+
+The training images install Python packages from a **private AIPCC PyPI index** (not public PyPI). Each image's Dockerfile specifies its index URL via `--index-url` — read it from the Dockerfile of the affected image.
+
+When fixing a CVE that requires bumping a Python dependency version:
+
+1. **Do NOT assume the upstream fix version is available.** The private index may not mirror every version from public PyPI.
+2. **Query the index to find available versions.** Read the `--index-url` from the affected image's Dockerfile, then fetch `{index-url}/{package}/` to find which versions are available.
+3. **If the package is a direct dependency** listed in `pyproject.toml`, update the version constraint there and **regenerate `requirements.txt`** using `uv pip compile` with the index URL from the Dockerfile (see [Regenerate Requirements](#regenerate-requirements-with-hashes) below).
+4. **If the package is a transitive dependency** (only in `requirements.txt`, not in `pyproject.toml`), update the pinned version directly in `requirements.txt` using the exact pin format (`package==x.y.z`).
+
+---
+
 ## How to Update
 
 Both scenarios require coordination with:


### PR DESCRIPTION
## Summary
- Adds agent instructions to `AGENTS.md` for handling CVE fixes that require Python dependency updates
- Guides autofix bot to read the private AIPCC PyPI index URL from the affected image's Dockerfile and query it for available versions before pinning
- Prevents repeated blocked iterations from pinning to versions unavailable in the private index

## Context
Multiple autofix runs (RHOAIENG-64929, RHOAIENG-64921, RHOAIENG-64912) were blocked because the bot pinned to upstream fix versions not mirrored in the AIPCC index. Adding these instructions to AGENTS.md (which the triage+resolve skills read as authoritative) should prevent this class of failure.

## Test plan
- [ ] Verify autofix bot reads the new instructions on next CVE triage run
- [ ] Confirm bot queries the index URL from the Dockerfile instead of assuming upstream version availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on CVE fixes and Python dependency updates when using a private package index.
  * Notes that package versions may differ from public PyPI and advises querying the private index before pinning versions.
  * Provides steps to update pinned versions and regenerate requirements using the same private index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->