### PR TITLE
Add upper-bounded version range guidance for CVE fixes

### DIFF
--- a/images/runtime/training/README.md
+++ b/images/runtime/training/README.md
@@ -5,11 +5,12 @@ This guide explains how to add new Python dependencies to the training runtime i
 ## Quick Start
 
 1. **Edit the Pipfile** for the image you want to update (e.g., `py312-cuda128-torch280/Pipfile`)
-2. **Add your dependencies** under `[packages]`:
+2. **Add your dependencies** under `[packages]` with a compatible release constraint to prevent supply-chain drift:
    ```toml
    [packages]
-   your-package = ">=1.0.0"
+   your-package = "~=1.0.0"
    ```
+   `~=X.Y.Z` is equivalent to `>=X.Y.Z,<X.(Y+1).0`, pinning to the current minor series. Unbounded `>=` allows silent upgrades that may introduce new vulnerabilities on lock refresh.
 3. **Generate the lock file** using the pre-built image (see below)
 
 ## Generating Lock Files

--- a/images/universal/training/README.md
+++ b/images/universal/training/README.md
@@ -95,6 +95,7 @@ When fixing a CVE that requires bumping a Python dependency version:
 2. **Query the index to find available versions.** Read the `--index-url` from the affected image's Dockerfile, then fetch `{index-url}/{package}/` to find which versions are available.
 3. **If the package is a direct dependency** listed in `pyproject.toml`, update the version constraint there and **regenerate `requirements.txt`** using `uv pip compile` with the index URL from the Dockerfile (see [Regenerate Requirements](#regenerate-requirements-with-hashes) below).
 4. **If the package is a transitive dependency** (only in `requirements.txt`, not in `pyproject.toml`), update the pinned version directly in `requirements.txt` using the exact pin format (`package==x.y.z`).
+5. **Use compatible release constraints** when adding or updating constraints in `pyproject.toml` or `Pipfile`. Use `~=X.Y.Z` (equivalent to `>=X.Y.Z,<X.(Y+1).0`) to pin to the current minor series (e.g., `~=3.14.0`). Unbounded `>=X.Y.Z` allows silent upgrades on lock refresh that may introduce new vulnerabilities.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds step 5 to the CVE fix guidance in `images/universal/training/README.md` requiring upper-bounded version ranges (`>=X.Y.Z,<X.(Y+1).0`) instead of unbounded `>=X.Y.Z`
- Updates the Quick Start example in `images/runtime/training/README.md` to use upper-bounded ranges
- Prevents supply-chain drift on lock refresh

Prompted by [PR #874 review feedback](https://github.com/opendatahub-io/distributed-workloads/pull/874#discussion_r3349984276).

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated training/runtime dependency guidance to improve supply-chain stability
  * Recommend using minor-series bounded constraints (e.g., ~=X.Y.Z / equivalent >=X.Y.Z,<X.(Y+1).0)
  * Added guidance for CVE fixes to prefer upper-bounded version ranges
  * Discourage unbounded minimum version constraints for dependencies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->