### PR TITLE
Fix Konflux build failure for torch280 training images

### DIFF
--- a/images/runtime/training/py312-cuda128-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch280/Pipfile.lock
@@ -272,13 +272,6 @@
             "markers": "python_version >= '3.9'",
             "version": "==1.41.5"
         },
-        "causal-conv1d": {
-            "hashes": [
-                "sha256:245e314ea21064ded7a5bf6b3b842b644aa6f92e45cecfe3e935629744c35ff4"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==1.6.2.post1"
-        },
         "certifi": {
             "hashes": [
                 "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
@@ -477,13 +470,6 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==3.29.1"
-        },
-        "flash-attn": {
-            "hashes": [
-                "sha256:1e71dd64a9e0280e0447b8a0c2541bad4bf6ac65bdeaa2f90e51a9e57de0370d"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.8.3"
         },
         "frozenlist": {
             "hashes": [
@@ -861,16 +847,6 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==0.47.0"
-        },
-        "mamba-ssm": {
-            "extras": [
-                "causal-conv1d"
-            ],
-            "hashes": [
-                "sha256:4d529477ad94753962216d583fc8f1c127c717b7d7c875d6bbb9376366d0d761"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.3.1"
         },
         "markdown": {
             "hashes": [

--- a/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
@@ -312,13 +312,6 @@
             "markers": "python_version >= '3.10'",
             "version": "==7.0.1"
         },
-        "causal-conv1d": {
-            "hashes": [
-                "sha256:245e314ea21064ded7a5bf6b3b842b644aa6f92e45cecfe3e935629744c35ff4"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==1.6.2.post1"
-        },
         "certifi": {
             "hashes": [
                 "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
@@ -999,16 +992,6 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==0.44.0"
-        },
-        "mamba-ssm": {
-            "extras": [
-                "causal-conv1d"
-            ],
-            "hashes": [
-                "sha256:104cc47e9101e5401a675fa2b784f2952b9b037f3b1dd83b5ac544394e95d028"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.3.2.post1"
         },
         "markdown": {
             "hashes": [


### PR DESCRIPTION
## Summary

- Fixes Konflux build failure introduced by #906 (CVE-2026-5241 fix) where `micropipenv install` fails trying to build `mamba-ssm` and `causal-conv1d` from source with the wrong torch version in pip's build isolation environment
- Removes CUDA-compiled packages from `Pipfile.lock` that cannot be installed via `micropipenv` due to pip build isolation pulling `torch 2.12.0+cu130` from PyPI instead of the pinned `torch 2.8.0+cu128`

### Changes

- **py312-cuda128-torch280/Pipfile.lock**: Remove `flash-attn`, `mamba-ssm`, `causal-conv1d` — already installed via `--no-build-isolation` in `Dockerfile.konflux` (lines 112-114)
- **py312-rocm64-torch280/Pipfile.lock**: Remove `mamba-ssm`, `causal-conv1d` — spurious transitive deps pulled in during lockfile re-resolution, not needed (image uses `training-hub==0.2.0` without `[cuda]` extra). `flash-attn` is kept as it was present before #906

### Root cause

When `training-hub[cuda]` resolves dependencies, `mamba-ssm[causal-conv1d]>=2.2.5` gets locked. These packages have no prebuilt wheels on PyPI — they must compile from source with CUDA. Pip's build isolation creates a fresh environment and installs `torch` from PyPI (latest `2.12.0+cu130`) instead of from the `pytorch-cu128` index, causing a CUDA version mismatch (`12.8` vs `13.0`).

## Test plan

- [ ] Verify Konflux build succeeds for `odh-training-cuda128-torch28-py312`
- [ ] Verify Konflux build succeeds for `odh-training-rocm64-torch28-py312`
- [ ] Verify `mamba-ssm`, `causal-conv1d`, `flash-attn` are present in the final CUDA image (installed by Dockerfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)