### PR TITLE
Skip CSV relatedImages check for universal training images

### DIFF
--- a/tests/trainer/cluster_training_runtimes_test.go
+++ b/tests/trainer/cluster_training_runtimes_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package trainer
 
 import (
+	"strings"
 	"testing"
 
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -296,6 +297,12 @@ func verifyPodContainerImages(test Test, namespace, trainJobName string) {
 			test.Expect(image).To(HavePrefix(imagePrefix), "Image %s should have prefix %s", image, imagePrefix)
 			test.Expect(image).To(MatchRegexp(`@sha256:[a-f0-9]{64}$`),
 				"Image %s should be SHA-based with valid digest", image)
+
+			// Universal images (th06) are not listed in CSV relatedImages
+			if strings.Contains(image, "/odh-th06-") {
+				test.T().Logf("Skipping CSV relatedImages check for universal image %s", image)
+				continue
+			}
 
 			// Verify image is listed in CSV related images
 			test.Expect(csv.Spec.RelatedImages).To(ContainElement(HaveField("Image", Equal(image))),


### PR DESCRIPTION
## Summary
- Skip CSV `spec.relatedImages` verification for universal training images (`odh-th06-*`) in `TestRunTrainJobWithDefaultClusterTrainingRuntimes`, as these images are no longer listed in the operator CSV
- Non-universal images (`odh-training-*`) continue to be verified against CSV relatedImages

## Test plan
- [x] Ran `TestRunTrainJobWithDefaultClusterTrainingRuntimes` with fix — all 5 unique runtimes pass
- [x] Ran without fix — fails on first universal image (`odh-th06-cuda130-torch210-py312` not in CSV)
- [x] Verified non-universal images (`odh-training-cuda128-torch29-py312`, `odh-training-rocm64-torch29-py312`) still checked against CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test validation for container images by conditionally skipping verification for specific universal image types while maintaining existing checks for other images. Enhanced test logging to provide better visibility into validation skips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->