### PR TITLE
Update Tekton release pipelines for odh-3.4

### DIFF
--- a/.tekton/odh-th06-cpu-torch210-py312-ci-on-release-push.yaml
+++ b/.tekton/odh-th06-cpu-torch210-py312-ci-on-release-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "release/odh-3.5-ea.1"
+      && target_branch == "release/odh-3.4-ga"
       && ( "images/universal/training/th06-cpu-torch210-py312/**".pathChanged() || ".tekton/odh-th06-cpu-torch210-py312-ci-on-release-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.5-ea1
+    value: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/odh-th06-cuda130-torch210-py312-ci-on-release-push.yaml
+++ b/.tekton/odh-th06-cuda130-torch210-py312-ci-on-release-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "release/odh-3.5-ea.1"
+      && target_branch == "release/odh-3.4-ga"
       && ( "images/universal/training/th06-cuda130-torch210-py312/**".pathChanged() || ".tekton/odh-th06-cuda130-torch210-py312-ci-on-release-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.5-ea1
+    value: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/odh-th06-rocm64-torch291-py312-release-push.yaml
+++ b/.tekton/odh-th06-rocm64-torch291-py312-release-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release/odh-3.5-ea.1" && ( "images/universal/training/th06-rocm64-torch291-py312/**".pathChanged() || ".tekton/odh-th06-rocm64-torch291-py312-release-push.yaml".pathChanged() )
+      == "release/odh-3.4-ga" && ( "images/universal/training/th06-rocm64-torch291-py312/**".pathChanged() || ".tekton/odh-th06-rocm64-torch291-py312-release-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.5-ea1
+    value: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.4
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-release-push.yaml
+++ b/.tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-release-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "release/odh-3.5-ea.1"
+      && target_branch == "release/odh-3.4-ga"
       && ( "images/runtime/training/py312-cuda130-torch210-openmpi41/**".pathChanged()
             || ".tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-release-push.yaml".pathChanged() )
   creationTimestamp: null
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-3.5-ea1
+    value: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-3.4
   - name: dockerfile
     value: Dockerfile
   - name: path-context


### PR DESCRIPTION
Updates the 4 release-push Tekton pipeline files to target branch release/odh-3.4-ga and image tag odh-3.4.