### PR TITLE
fix: disable build isolation for rocm280 dependency install

### DIFF
--- a/images/runtime/training/py312-rocm64-torch280/Dockerfile
+++ b/images/runtime/training/py312-rocm64-torch280/Dockerfile
@@ -56,7 +56,7 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]"
 # Install Python dependencies from Pipfile.lock file
 COPY Pipfile.lock ./
 
-RUN micropipenv install -- --no-cache-dir && \
+RUN PIP_NO_BUILD_ISOLATION=1 micropipenv install -- --no-cache-dir && \
     rm -f ./Pipfile.lock && \
     # Fix permissions to support pip in OpenShift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \


### PR DESCRIPTION
Flash-attn's build hooks import torch, which fails under pip build isolation during micropipenv installation in the py312-rocm64-torch280 image. Set PIP_NO_BUILD_ISOLATION=1 for the install step so torch is visible and the image build no longer fails at flash-attn resolution.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of environment setup during training image builds, reducing install failures in some cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->