### PR TITLE
fix: install rocm280 flash-attn outside lockfile on main

### DIFF
--- a/images/runtime/training/py312-rocm64-torch280/Dockerfile
+++ b/images/runtime/training/py312-rocm64-torch280/Dockerfile
@@ -78,6 +78,10 @@ RUN export TMP_DIR=$(mktemp -d) \
 RUN chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P
 
+# Install flash-attn outside lockfile resolution; it needs torch visible at build time.
+RUN pip install --no-build-isolation --no-cache-dir --no-deps flash-attn==2.8.3 && \
+    fix-permissions /opt/app-root -P
+
 # Restore user workspace
 USER 1001
 

--- a/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
+++ b/images/runtime/training/py312-rocm64-torch280/Pipfile.lock
@@ -605,13 +605,6 @@
             "markers": "python_version >= '3.10'",
             "version": "==3.29.1"
         },
-        "flash-attn": {
-            "hashes": [
-                "sha256:1e71dd64a9e0280e0447b8a0c2541bad4bf6ac65bdeaa2f90e51a9e57de0370d"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==2.8.3"
-        },
         "frozenlist": {
             "hashes": [
                 "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686",


### PR DESCRIPTION
Flash-attn build hooks can fail during micropipenv lockfile installation with torch import errors in this image path. Remove flash-attn from lockfile resolution and install it explicitly with no-build-isolation after base dependencies are installed.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional attention optimization package in the Python 3.12 ROCm training image.
  * Improved the training environment setup so builds complete with the required dependencies already available.

* **Bug Fixes**
  * Resolved build-time issues related to package installation order, helping training images build more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->