### PR TITLE
Fix preflight certification checks for cu129-th081 image

### DIFF
--- a/images/runtime/ray/cuda/2.55.1-py312-cu129-th081/Dockerfile
+++ b/images/runtime/ray/cuda/2.55.1-py312-cu129-th081/Dockerfile
@@ -28,7 +28,8 @@ RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3
 ENV CUDA_VERSION=12.9.2
 
 COPY cuda.repo-* ./
-COPY NGC-DL-CONTAINER-LICENSE /
+RUN mkdir -p /licenses
+COPY NGC-DL-CONTAINER-LICENSE /licenses/
 
 RUN if [ "${TARGETARCH}" = "arm64" ]; then \
         cp cuda.repo-arm64 /etc/yum.repos.d/cuda.repo; \
@@ -129,7 +130,8 @@ RUN yum install -y \
     ${NV_CUDNN_PACKAGE} \
     ${NV_CUDNN_PACKAGE_DEV} \
     && yum clean all \
-    && rm -rf /var/cache/yum/*
+    && rm -rf /var/cache/yum/* \
+    && rpm --restore redhat-rpm-config
 
 # ---------------------------------------------------------------------------
 # Install Python packages


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Following on from failures in the konflux build pipeline for the new ray with training hub image, the following need to be added:
 - Move NGC-DL-CONTAINER-LICENSE into /licenses/ directory to satisfy HasLicense check, 
 - Restore redhat-rpm-config after yum installs to fix HasModifiedFiles check on redhat-annobin-cc1.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This will be tested by seeing a successful build in konflux.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA image build reliability by restoring repository configuration during installation.
  * Updated license file placement to keep licenses organized in a dedicated directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->