### PR TITLE
RHOAIENG-76553: Preserve restart logs and skip unstable ROCm multi-node test

### DIFF
--- a/tests/common/support/core.go
+++ b/tests/common/support/core.go
@@ -188,14 +188,19 @@ func startPeriodicPodLogCapture(t Test, namespace *corev1.Namespace) context.Can
 	done := make(chan struct{})
 	client := t.Client().Core().CoreV1()
 
+	// Track restart counts to preserve logs from every container crash.
+	// Key: "podName/containerName", value: last observed restartCount.
+	lastRestartCount := map[string]int32{}
+
 	writeFile := func(filePath string, data []byte) {
 		if err := os.WriteFile(filePath, data, 0o600); err != nil {
 			t.T().Logf("periodic pod capture: failed writing %s: %v", filePath, err)
 		}
 	}
 
-	fetchLog := func(outputDir, podName, containerName string, previous bool) {
+	fetchLog := func(outputDir, podName, containerName, suffix string) {
 		tailLines := int64(10000)
+		previous := suffix != ""
 		options := corev1.PodLogOptions{Container: containerName, Previous: previous, TailLines: &tailLines}
 		stream, err := client.Pods(namespace.Name).GetLogs(podName, &options).Stream(ctx)
 		if err != nil {
@@ -208,11 +213,40 @@ func startPeriodicPodLogCapture(t Test, namespace *corev1.Namespace) context.Can
 			return
 		}
 
-		suffix := ""
-		if previous {
-			suffix = "-previous"
-		}
 		writeFile(path.Join(outputDir, "pod-"+podName+"-"+containerName+suffix+".log"), data)
+	}
+
+	containerRestartCount := func(pod corev1.Pod, containerName string) int32 {
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name == containerName {
+				return cs.RestartCount
+			}
+		}
+		for _, cs := range pod.Status.InitContainerStatuses {
+			if cs.Name == containerName {
+				return cs.RestartCount
+			}
+		}
+		return 0
+	}
+
+	captureContainerLogs := func(outputDir string, pod corev1.Pod, containerName string) {
+		fetchLog(outputDir, pod.Name, containerName, "")
+
+		restartCount := containerRestartCount(pod, containerName)
+		key := pod.Name + "/" + containerName
+
+		if restartCount > 0 {
+			fetchLog(outputDir, pod.Name, containerName, "-previous")
+		}
+
+		if restartCount > lastRestartCount[key] {
+			// Restart count increased — save the previous log with the restart
+			// number so it is not overwritten by subsequent crashes.
+			fetchLog(outputDir, pod.Name, containerName, fmt.Sprintf("-restart-%d", restartCount))
+		}
+
+		lastRestartCount[key] = restartCount
 	}
 
 	go func() {
@@ -234,13 +268,11 @@ func startPeriodicPodLogCapture(t Test, namespace *corev1.Namespace) context.Can
 
 				for _, pod := range pods.Items {
 					for _, container := range pod.Spec.InitContainers {
-						fetchLog(outputDir, pod.Name, container.Name, false)
-						fetchLog(outputDir, pod.Name, container.Name, true)
+						captureContainerLogs(outputDir, pod, container.Name)
 					}
 
 					for _, container := range pod.Spec.Containers {
-						fetchLog(outputDir, pod.Name, container.Name, false)
-						fetchLog(outputDir, pod.Name, container.Name, true)
+						captureContainerLogs(outputDir, pod, container.Name)
 					}
 
 					status := map[string]any{

--- a/tests/kfto/kfto_mnist_training_test.go
+++ b/tests/kfto/kfto_mnist_training_test.go
@@ -94,6 +94,7 @@ func TestPyTorchJobMnistMultiNodeSingleGpuWithROCmPyTorch251(t *testing.T) {
 }
 
 func TestPyTorchJobMnistMultiNodeMultiGpuWithROCmPyTorch241(t *testing.T) {
+	t.Skip("RHOAIENG-76553: ROCm 6.2 + PyTorch 2.4.1 RCCL is unstable for multi-node multi-GPU, causes cross-node communication hangs")
 	Tags(t, KftoRocm)
 	test := With(t)
 	runKFTOPyTorchMnistJob(test, AMD, GetTrainingROCmPyTorch241Image(test), "resources/requirements-rocm.txt", 1, 2)


### PR DESCRIPTION
## Summary
- Preserve container logs from every restart in the periodic pod log capture. Previously the `-previous.log` was overwritten each 3s tick, losing earlier crash logs. Now each restart also saves a numbered `-restart-<N>.log` that is never overwritten — critical for diagnosing the initial crash in multi-restart scenarios (e.g., NCCL/RCCL failures where `restartCount` reaches 4 and only the last crash is visible).
- Skip `TestPyTorchJobMnistMultiNodeMultiGpuWithROCmPyTorch241` — ROCm 6.2 + PyTorch 2.4.1 RCCL hangs on cross-node multi-GPU communication. Other PyTorch versions (2.5.1, 2.8) and single-node multi-GPU pass reliably.

## Test plan
- [x] `go vet` and `golangci-lint` pass with 0 issues
- [x] `TestPyTorchDDPMultiNodeMultiCPUWithTorchCuda28` passes on live cluster — verified no regressions in log capture (no spurious `-restart-*` or `-previous` files when containers don't restart)
- [x] Verified restart log preservation with a crashing pod on live cluster — `-restart-1.log`, `-restart-2.log`, `-restart-3.log` all created with distinct content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod log capture across container restarts, preserving earlier crash logs instead of overwriting them.

* **Tests**
  * Temporarily skipped a multi-node, multi-GPU ROCm PyTorch test due to known communication instability that can cause hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->