### PR TITLE
CVE-2026-54283: bump starlette 1.2.0 → 1.3.1

### DIFF
--- a/images/runtime/training/py312-cuda128-torch290/Pipfile
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile
@@ -52,7 +52,7 @@ mlflow = "==3.10.1"
 simpleeval = "==1.0.7"
 cryptography = ">=46.0.7"
 urllib3 = ">=2.7.0"
-starlette = ">=1.0.1"
+starlette = "~=1.3.1"
 pillow = ">=12.3.0"
 
 [dev-packages]

--- a/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
+++ b/images/runtime/training/py312-cuda128-torch290/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "462602d8d652f46e9d80a13390cb6cb75aee0b97e30514206b512a3a8f1a71a6"
+            "sha256": "a9e201761400ea6613914aa4032e51c9df7b065aecab3677488f07e0ad51f5f7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -231,11 +231,11 @@
         },
         "anyio": {
             "hashes": [
-                "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708",
-                "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"
+                "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494",
+                "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.13.0"
+            "version": "==4.14.2"
         },
         "async-timeout": {
             "hashes": [
@@ -3494,12 +3494,12 @@
         },
         "starlette": {
             "hashes": [
-                "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f",
-                "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd"
+                "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0",
+                "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==1.0.1"
+            "version": "==1.3.1"
         },
         "sympy": {
             "hashes": [
@@ -3710,11 +3710,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
-                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+                "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8",
+                "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==4.15.0"
+            "version": "==4.16.0"
         },
         "typing-inspection": {
             "hashes": [

--- a/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
+++ b/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
@@ -85,4 +85,5 @@ index-strategy = "unsafe-best-match"
 index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/"
 constraint-dependencies = [
     "aiohttp~=3.14.0",
+    "starlette~=1.3.1",
 ]

--- a/images/universal/training/th06-cpu-torch210-py312/requirements.txt
+++ b/images/universal/training/th06-cpu-torch210-py312/requirements.txt
@@ -515,7 +515,7 @@ sqlalchemy==2.0.49
     #   mlflow
 sqlparse==0.5.5
     # via mlflow-skinny
-starlette==1.2.0
+starlette==1.3.1
     # via fastapi
 sympy==1.14.0
     # via

--- a/images/universal/training/th06-cuda130-torch210-py312/pyproject.toml
+++ b/images/universal/training/th06-cuda130-torch210-py312/pyproject.toml
@@ -103,4 +103,5 @@ index-strategy = "unsafe-best-match"
 index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda13.0-ubi9/simple/"
 constraint-dependencies = [
     "aiohttp~=3.14.0",
+    "starlette~=1.3.1",
 ]

--- a/images/universal/training/th06-cuda130-torch210-py312/requirements.txt
+++ b/images/universal/training/th06-cuda130-torch210-py312/requirements.txt
@@ -611,7 +611,7 @@ sqlalchemy==2.0.49
     #   mlflow
 sqlparse==0.5.5
     # via mlflow-skinny
-starlette==1.2.0
+starlette==1.3.1
     # via fastapi
 sympy==1.14.0
     # via

--- a/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
+++ b/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
@@ -90,4 +90,5 @@ index-strategy = "unsafe-best-match"
 index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/rocm6.4-ubi9/simple/"
 constraint-dependencies = [
     "aiohttp~=3.14.0",
+    "starlette~=1.3.1",
 ]

--- a/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
+++ b/images/universal/training/th06-rocm64-torch291-py312/requirements.txt
@@ -594,7 +594,7 @@ sqlalchemy==2.0.49
     #   mlflow
 sqlparse==0.5.5
     # via mlflow-skinny
-starlette==1.2.0
+starlette==1.3.1
     # via fastapi
 sympy==1.14.0
     # via


### PR DESCRIPTION
## Summary

- Bump `starlette` 1.2.0 → 1.3.1 across all affected training images to fix **CVE-2026-54283** (CVSS 7.5, Moderate)
- **Universal images (th06):** all 3 variants (cpu, cuda, rocm) updated in `requirements.txt` — starlette 1.3.1 already on AIPCC 3.4 indexes (AIPCC-18628)
- **Runtime images:** cuda128 updated in Pipfile + re-locked; rocm64 not affected (no fastapi/starlette)

## CVE Details

**CVE-2026-54283** — Starlette: `request.form()` limits (`max_fields`, `max_part_size`) silently ignored for `application/x-www-form-urlencoded`, enabling DoS via unbounded memory allocation or event loop blocking.

## Affected Images

| Image | Family | Change |
|---|---|---|
| th06-cpu-torch210-py312 | universal | starlette bump |
| th06-cuda130-torch210-py312 | universal | starlette bump |
| th06-rocm64-torch291-py312 | universal | starlette bump |
| py312-cuda128-torch290 | runtime | starlette Pipfile + re-lock |

## Test plan

- [ ] Verify Konflux builds succeed for all 4 affected images
- [ ] Verify `pip show starlette` shows 1.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Starlette dependency to `1.3.1` across supported training environments.
  * Refreshed autogenerated requirements to ensure pinned versions align with `1.3.1`.
  * Added/updated Starlette compatibility constraints in the environment resolver configuration to keep dependency resolution consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->