### PR TITLE
fix: update safetensors 0.7.0 → 0.8.0 in th06 pyproject.toml

### DIFF
--- a/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
+++ b/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pydantic>=2.11.7",
     "protobuf>=3.20.0",
     "simpleeval>=0.9.13",
-    "safetensors==0.7.0",
+    "safetensors==0.8.0",
     "py-cpuinfo>=9.0.0",
     "rich>=13.9.4",
     "aiofiles==25.1.0",

--- a/images/universal/training/th06-cuda130-torch210-py312/pyproject.toml
+++ b/images/universal/training/th06-cuda130-torch210-py312/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "typer>=0.19.2",
     "protobuf>=3.20.0",
     "simpleeval>=0.9.13",
-    "safetensors==0.7.0",
+    "safetensors==0.8.0",
     "py-cpuinfo>=9.0.0",
     
     # Deep Learning Utilities

--- a/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
+++ b/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "pydantic>=2.11.7",
     "protobuf>=3.20.0",
     "simpleeval>=0.9.13",
-    "safetensors==0.7.0",
+    "safetensors==0.8.0",
     "py-cpuinfo==9.0.0",
     "rich>=13.9.4",
     "aiofiles==25.1.0",


### PR DESCRIPTION
## Summary

Follow-up to #954 (CVE-2026-44513 diffusers fix) — `requirements.txt` was bumped to `safetensors==0.8.0` but `pyproject.toml` still had `safetensors==0.7.0`. Next `uv pip compile` would revert the fix.

Updates all 3 th06 pyproject.toml files (cpu, cuda, rocm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Safetensors package to version 0.8.0 across CPU, CUDA, and ROCm training environments.
  * Ensures these environments use the latest specified package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->