### PR TITLE
RHOAIENG-76553: Skip unstable ROCm multi-node multi-GPU MNIST tests

### DIFF
--- a/tests/kfto/kfto_mnist_training_test.go
+++ b/tests/kfto/kfto_mnist_training_test.go
@@ -101,12 +101,14 @@ func TestPyTorchJobMnistMultiNodeMultiGpuWithROCmPyTorch241(t *testing.T) {
 }
 
 func TestPyTorchJobMnistMultiNodeMultiGpuWithROCmPyTorch251(t *testing.T) {
+	t.Skip("RHOAIENG-76553: ROCm multi-node multi-GPU RCCL is unstable, causes cross-node communication hangs")
 	Tags(t, KftoRocm)
 	test := With(t)
 	runKFTOPyTorchMnistJob(test, AMD, GetTrainingROCmPyTorch251Image(test), "resources/requirements-rocm.txt", 1, 2)
 }
 
 func TestPyTorchJobMnistMultiNodeMultiGpuWithROCmPyTorch28(t *testing.T) {
+	t.Skip("RHOAIENG-76553: ROCm multi-node multi-GPU RCCL is unstable, causes cross-node communication hangs")
 	Tags(t, KftoRocm)
 	test := With(t)
 	runKFTOPyTorchMnistJob(test, AMD, GetTrainingRocmPyTorch28Image(test), "resources/requirements-rocm.txt", 1, 2)


### PR DESCRIPTION
## Summary
- Skip `TestPyTorchJobMnistMultiNodeMultiGpuWithROCmPyTorch251` and `TestPyTorchJobMnistMultiNodeMultiGpuWithROCmPyTorch28` — same treatment as the already-skipped torch241 variant
- ROCm RCCL over Socket transport causes silent hangs during cross-node collective operations on Azure AMD clusters
- The torch28 test was the sole failure making `rhoai-rocm-gpu #2` UNSTABLE (all 11 Trainer tests and 12 other KFTO tests passed)

## Root cause
Analysis of [rhoai-rocm-gpu #2](https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/rhoai/job/3.5/job/selfmanaged/job/cli/job/azure/job/gpu/job/amd/job/rhoai-rocm-gpu/2/) showed:
- Training started on all 4 GPUs (2 nodes x 2 AMD GPUs) but hung silently on Epoch 0 — no progress for 8.5 minutes until the test timed out and sent SIGTERM
- Contributing factor: `requirements-rocm.txt` uses `--extra-index-url rocm6.1`, which installs RCCL 2.18.6 (ROCm 6.1) on top of the torch28 image's ROCm 6.4 stack — a version mismatch that worsens the instability
- The torch241 variant was already skipped with the same RHOAIENG-76553 reference for the same "cross-node communication hangs"

## Test plan
- [x] Verify torch241 is already skipped (line 97)
- [x] Verify torch251 and torch28 multi-GPU tests get the same skip treatment
- [x] Single-GPU and LLM multi-node tests are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily skipped ROCm multi-node, multi-GPU training tests for PyTorch 2.5.1 and 2.8 due to known RCCL multi-node instability.
  * Updated the skip explanation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->