### PR TITLE
Use >= for CVE constraint-dependencies, add pyasn1>=0.6.4

### DIFF
--- a/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
+++ b/images/universal/training/th06-cpu-torch210-py312/pyproject.toml
@@ -84,8 +84,9 @@ environments = [
 index-strategy = "unsafe-best-match"
 index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple/"
 constraint-dependencies = [
-    "aiohttp~=3.14.0",
-    "gitpython~=3.1.50",
-    "pillow~=12.3.0",
-    "starlette~=1.3.1",
+    "aiohttp>=3.14.0",
+    "gitpython>=3.1.50",
+    "pillow>=12.3.0",
+    "starlette>=1.3.1",
+    "pyasn1>=0.6.4",
 ]

--- a/images/universal/training/th06-cuda130-torch210-py312/pyproject.toml
+++ b/images/universal/training/th06-cuda130-torch210-py312/pyproject.toml
@@ -102,8 +102,9 @@ environments = [
 index-strategy = "unsafe-best-match"
 index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda13.0-ubi9/simple/"
 constraint-dependencies = [
-    "aiohttp~=3.14.0",
-    "gitpython~=3.1.50",
-    "pillow~=12.3.0",
-    "starlette~=1.3.1",
+    "aiohttp>=3.14.0",
+    "gitpython>=3.1.50",
+    "pillow>=12.3.0",
+    "starlette>=1.3.1",
+    "pyasn1>=0.6.4",
 ]

--- a/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
+++ b/images/universal/training/th06-rocm64-torch291-py312/pyproject.toml
@@ -89,8 +89,9 @@ environments = [
 index-strategy = "unsafe-best-match"
 index-url = "https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/rocm6.4-ubi9/simple/"
 constraint-dependencies = [
-    "aiohttp~=3.14.0",
-    "gitpython~=3.1.50",
-    "pillow~=12.3.0",
-    "starlette~=1.3.1",
+    "aiohttp>=3.14.0",
+    "gitpython>=3.1.50",
+    "pillow>=12.3.0",
+    "starlette>=1.3.1",
+    "pyasn1>=0.6.4",
 ]


### PR DESCRIPTION
## Summary

- Switch CVE `constraint-dependencies` from `~=` (compatible release) to `>=` (minimum version) in all universal training `pyproject.toml` files
- Add `pyasn1>=0.6.4` constraint for CVE-2026-59884, CVE-2026-59885, CVE-2026-59886

## Rationale

CVE constraint-dependencies are version floors to prevent regression below a security fix. The AIPCC frozen index already controls which versions are available, making the upper bound from `~=` redundant. Using `>=` ensures future minor versions with additional security fixes are not silently blocked.

## Changes

- `images/universal/training/th06-cpu-torch210-py312/pyproject.toml`
- `images/universal/training/th06-cuda130-torch210-py312/pyproject.toml`
- `images/universal/training/th06-rocm64-torch291-py312/pyproject.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependency Updates**
  * Loosened version constraints for `aiohttp`, `gitpython`, `pillow`, and `starlette` from compatible-release pins to minimum-version requirements across training environments.
  * Added `pyasn1>=0.6.4` as a constraint to align required cryptography support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->