### PR TITLE
Run go vet on rhoai-* release branches

### DIFF
--- a/.github/workflows/go-vet.yml
+++ b/.github/workflows/go-vet.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'rhoai-*'
     paths:
       - '**.go'
       - '**go.mod'


### PR DESCRIPTION
## Summary
- Add `rhoai-*` branch pattern to the `go-vet.yml` push trigger so that direct pushes to release branches are also validated

## Motivation
A cherry-pick with undefined symbols landed on `rhoai-3.3` undetected because `go vet` only ran on pushes to `main`. Adding `rhoai-*` ensures compilation errors are caught on release branches too.

## Test plan
- [x] Verified the workflow YAML is valid
- [x] No functional code changes — workflow trigger only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended automated code quality checks to run when changes are pushed to `rhoai-*` branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->