### PR TITLE
chore: remove leftover template comments from th-torch pull-request pipelines

### DIFF
--- a/.tekton/odh-th-torch-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-th-torch-cpu-py312-pull-request.yaml
@@ -28,7 +28,6 @@ spec:
     value: Dockerfile
   - name: path-context
     value: images/universal/training/th-torch-cpu-py312
-  #add these additional params
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/.tekton/odh-th-torch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-th-torch-cuda-py312-pull-request.yaml
@@ -28,7 +28,6 @@ spec:
     value: Dockerfile
   - name: path-context
     value: images/universal/training/th-torch-cuda-py312
-  #add these additional params
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/.tekton/odh-th-torch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-th-torch-rocm-py312-pull-request.yaml
@@ -28,7 +28,6 @@ spec:
     value: Dockerfile
   - name: path-context
     value: images/universal/training/th-torch-rocm-py312
-  #add these additional params
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'


### PR DESCRIPTION
Removes the `#add these additional params` comment that was copied verbatim from the OKC pipeline template. The comment was a template authoring note and has no place in the generated files.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete comments from pipeline configuration files.
  * No functional changes were made to pipeline behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->