### PR TITLE
Align th-torch Tekton pipelines with pathChanged() filters

### DIFF
--- a/.tekton/odh-th-torch-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-th-torch-cpu-py312-pull-request.yaml
@@ -5,10 +5,14 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "main"
+      && ( "images/universal/training/th-torch-cpu-py312/**".pathChanged()
+            || ".tekton/odh-th-torch-cpu-py312-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -28,7 +32,6 @@ spec:
     value: Dockerfile
   - name: path-context
     value: images/universal/training/th-torch-cpu-py312
-  #add these additional params
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/.tekton/odh-th-torch-cpu-py312-push.yaml
+++ b/.tekton/odh-th-torch-cpu-py312-push.yaml
@@ -1,6 +1,5 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-#
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
@@ -8,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "main"
+      && ( "images/universal/training/th-torch-cpu-py312/**".pathChanged()
+            || ".tekton/odh-th-torch-cpu-py312-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/.tekton/odh-th-torch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-th-torch-cuda-py312-pull-request.yaml
@@ -5,10 +5,14 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "main"
+      && ( "images/universal/training/th-torch-cuda-py312/**".pathChanged()
+            || ".tekton/odh-th-torch-cuda-py312-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -28,7 +32,6 @@ spec:
     value: Dockerfile
   - name: path-context
     value: images/universal/training/th-torch-cuda-py312
-  #add these additional params
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/.tekton/odh-th-torch-cuda-py312-push.yaml
+++ b/.tekton/odh-th-torch-cuda-py312-push.yaml
@@ -1,6 +1,5 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-#
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
@@ -8,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "main"
+      && ( "images/universal/training/th-torch-cuda-py312/**".pathChanged()
+            || ".tekton/odh-th-torch-cuda-py312-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/.tekton/odh-th-torch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-th-torch-rocm-py312-pull-request.yaml
@@ -5,10 +5,14 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "main"
+      && ( "images/universal/training/th-torch-rocm-py312/**".pathChanged()
+            || ".tekton/odh-th-torch-rocm-py312-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -28,7 +32,6 @@ spec:
     value: Dockerfile
   - name: path-context
     value: images/universal/training/th-torch-rocm-py312
-  #add these additional params
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/.tekton/odh-th-torch-rocm-py312-push.yaml
+++ b/.tekton/odh-th-torch-rocm-py312-push.yaml
@@ -1,6 +1,5 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-#
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
@@ -8,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "main"
+      && ( "images/universal/training/th-torch-rocm-py312/**".pathChanged()
+            || ".tekton/odh-th-torch-rocm-py312-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds


### PR DESCRIPTION
## Summary
- Add `pathChanged()` CEL filters to all six `odh-th-torch-{cpu,cuda,rocm}-py312` PipelineRuns so builds only run when the image directory or PipelineRun file changes (matches existing `.tekton/` convention)
- Remove leftover template comments (`#add these additional params` and stray `#` on push pipelines)
- Add `build.appstudio.redhat.com/pull_request_number` on pull-request pipelines for consistency with peer manifests

Follow-up to review feedback on #982. Supersedes the comment-only cleanup in #983.

## Test plan
- [ ] Confirm CEL expressions match the pattern used by peer pipelines (e.g. `odh-training-cuda130-torch210-py312-openmpi41-ci-on-pull-request.yaml`)
- [ ] After merge, verify an unrelated PR to `main` does **not** trigger these three Konflux builds
- [ ] Verify a change under `images/universal/training/th-torch-cuda-py312/` triggers only the CUDA PipelineRun
- [ ] Close #983 as superseded (if still open)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build validation to run only for relevant image or pipeline configuration changes.
  * Added consistent filtering for changes targeting the main branch.
  * Improved trigger expressions for both pull request and push workflows.
  * Pull request validations now record the associated pull request number.
  * Removed outdated configuration comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->