### PR TITLE
Update trainer e2e expected CTRs and images

### DIFF
--- a/tests/trainer/README.md
+++ b/tests/trainer/README.md
@@ -42,7 +42,7 @@ kubectl apply --server-side -k "https://github.com/opendatahub-io/trainer.git/ma
 kubectl get deployments -n opendatahub kubeflow-trainer-controller-manager
 
 
-#Verify all four ClusterTrainingRuntimes are created
+# Verify ClusterTrainingRuntimes are created (defaults + pinned th09)
 
 ```bash
 kubectl get clustertrainingruntimes
@@ -101,5 +101,5 @@ Post-upgrade tests compare resource `metadata.generation` against pre-upgrade ba
 
 ## GPU Requirements
 
-> **Note:** The TrainingHub SDK tests (`TestOsftTrainingHubMultiNodeMultiGPU`, `TestLoraTrainingHubMultiNodeMultiGPU`, `TestSftTrainingHubMultiNodeMultiGPU`) require **NVIDIA Ampere or newer GPUs** (e.g. A100, H100). The training runtime image (`odh-training-cuda128-torch29-py312-rhel9`, referenced as `DefaultTrainingHubRuntimeCUDA` in [`tests/trainer/utils/utils_runtimes.go`](utils/utils_runtimes.go)) ships with `flash_attn==2.8.3`, which requires compute capability >= 8.0. These tests will not work on pre-Ampere GPUs such as T4 or V100.
+> **Note:** The TrainingHub SDK tests (`TestOsftTrainingHubMultiNodeMultiGPU`, `TestLoraTrainingHubMultiNodeMultiGPU`, `TestSftTrainingHubMultiNodeMultiGPU`) require **NVIDIA Ampere or newer GPUs** (e.g. A100, H100). The training runtime image (`odh-th-torch-cuda-py312`, referenced as `DefaultTrainingHubRuntimeCUDA` in [`tests/trainer/utils/utils_runtimes.go`](utils/utils_runtimes.go)) ships with `flash-attn==2.8.3.post1`, which requires compute capability >= 8.0. These tests will not work on pre-Ampere GPUs such as T4 or V100.
 

--- a/tests/trainer/cluster_training_runtimes_test.go
+++ b/tests/trainer/cluster_training_runtimes_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package trainer
 
 import (
-	"strings"
 	"testing"
 
 	trainerv1alpha1 "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -139,7 +138,7 @@ func TestOpenMPICudaClusterTrainingRuntime(t *testing.T) {
 }
 
 // TestDefaultTrainingHubRuntimesMatchDefaultClusterRuntimes is a smoke test that verifies
-// Training Hub and pinned torch-distributed CTR resources (th06) have exactly the same
+// Training Hub and pinned torch-distributed CTR resources have exactly the same
 // spec as their corresponding DefaultClusterTrainingRuntime resources.
 func TestDefaultTrainingHubRuntimesMatchDefaultClusterRuntimes(t *testing.T) {
 	Tags(t, Smoke)
@@ -298,13 +297,7 @@ func verifyPodContainerImages(test Test, namespace, trainJobName string) {
 			test.Expect(image).To(MatchRegexp(`@sha256:[a-f0-9]{64}$`),
 				"Image %s should be SHA-based with valid digest", image)
 
-			// Universal images (th06) are not listed in CSV relatedImages
-			if strings.Contains(image, "/odh-th06-") {
-				test.T().Logf("Skipping CSV relatedImages check for universal image %s", image)
-				continue
-			}
-
-			// Verify image is listed in CSV related images
+			// Verify image is listed in CSV related images (including odh-th-torch-* universal images)
 			test.Expect(csv.Spec.RelatedImages).To(ContainElement(HaveField("Image", Equal(image))),
 				"Image %s is not listed in CSV %s related images", image, csv.Name)
 			test.T().Logf("Image %s is verified in CSV related images", image)

--- a/tests/trainer/resources/disconnected_env/README.md
+++ b/tests/trainer/resources/disconnected_env/README.md
@@ -58,7 +58,7 @@ Disconnected environments require:
 
 ### TrainingHub SDK Tests
 
-> **Note:** These tests require **NVIDIA Ampere or newer GPUs** (e.g. A100, H100). The training runtime image (`odh-training-cuda128-torch29-py312-rhel9`, referenced as `DefaultTrainingHubRuntimeCUDA` in [`tests/trainer/utils/utils_runtimes.go`](../../utils/utils_runtimes.go)) ships with `flash_attn==2.8.3`, which requires compute capability >= 8.0. These tests will not work on pre-Ampere GPUs such as T4 or V100.
+> **Note:** These tests require **NVIDIA Ampere or newer GPUs** (e.g. A100, H100). The training runtime image (`odh-th-torch-cuda-py312`, referenced as `DefaultTrainingHubRuntimeCUDA` in [`tests/trainer/utils/utils_runtimes.go`](../../utils/utils_runtimes.go)) ships with `flash-attn==2.8.3.post1`, which requires compute capability >= 8.0. These tests will not work on pre-Ampere GPUs such as T4 or V100.
 
 | Test Name | Description | Resources |
 |-----------|-------------|-----------|

--- a/tests/trainer/utils/utils_runtimes.go
+++ b/tests/trainer/utils/utils_runtimes.go
@@ -85,40 +85,38 @@ func IsDefaultRuntime(name string) bool {
 }
 
 // TrainingHubToDefaultClusterRuntime maps each Training Hub and pinned torch-distributed
-// runtime (th06) to its corresponding DefaultClusterTrainingRuntime. Both runtimes in
+// runtime to its corresponding DefaultClusterTrainingRuntime. Both runtimes in
 // each pair are expected to have identical CTR specs (only metadata differs).
+// CTR names match manifests/rhoai/runtimes in opendatahub-io/trainer.
 var TrainingHubToDefaultClusterRuntime = map[string]string{
 	// Default (floating) runtimes
 	DefaultTrainingHubRuntimeCUDA: DefaultClusterTrainingRuntimeCUDA,
 	DefaultTrainingHubRuntimeCPU:  DefaultClusterTrainingRuntimeCPU,
 	DefaultTrainingHubRuntimeROCm: DefaultClusterTrainingRuntimeROCm,
-	// Pinned th06 runtimes (map to default runtimes; same image, identical spec)
-	"training-hub-th06-cuda130-torch210-py312": DefaultClusterTrainingRuntimeCUDA,
-	"training-hub-th06-cpu-torch210-py312":     DefaultClusterTrainingRuntimeCPU,
-	"training-hub-th06-rocm64-torch291-py312":  DefaultClusterTrainingRuntimeROCm,
-	"torch-distributed-cuda130-torch210-py312": DefaultClusterTrainingRuntimeCUDA,
-	"torch-distributed-cpu-torch210-py312":     DefaultClusterTrainingRuntimeCPU,
-	"torch-distributed-rocm64-torch291-py312":  DefaultClusterTrainingRuntimeROCm,
+	// Pinned runtimes (map to default runtimes; same image, identical spec)
+	"training-hub-th09-cuda130-torch211-py312": DefaultClusterTrainingRuntimeCUDA,
+	"training-hub-th09-cpu-torch211-py312":     DefaultClusterTrainingRuntimeCPU,
+	"training-hub-th09-rocm714-torch211-py312": DefaultClusterTrainingRuntimeROCm,
+	"torch-distributed-cuda130-torch211-py312": DefaultClusterTrainingRuntimeCUDA,
+	"torch-distributed-cpu-torch211-py312":     DefaultClusterTrainingRuntimeCPU,
+	"torch-distributed-rocm714-torch211-py312": DefaultClusterTrainingRuntimeROCm,
 }
 
 // ExpectedRuntimes is the list of expected ClusterTrainingRuntimes on the cluster
 var ExpectedRuntimes = []ClusterTrainingRuntime{
-	{Name: DefaultClusterTrainingRuntimeCUDA, Image: "odh-th06-cuda130-torch210-py312"},
-	{Name: DefaultClusterTrainingRuntimeROCm, Image: "odh-th06-rocm64-torch291-py312"},
-	{Name: DefaultClusterTrainingRuntimeCPU, Image: "odh-th06-cpu-torch210-py312"},
+	{Name: DefaultClusterTrainingRuntimeCUDA, Image: "odh-th-torch-cuda-py312"},
+	{Name: DefaultClusterTrainingRuntimeROCm, Image: "odh-th-torch-rocm-py312"},
+	{Name: DefaultClusterTrainingRuntimeCPU, Image: "odh-th-torch-cpu-py312"},
 	//	{Name: DefaultClusterTrainingRuntimeOpenMPICUDA, Image: DefaultClusterTrainingRuntimeOpenMPICUDAImage},
-	{Name: "torch-distributed-cuda128-torch29-py312", Image: "odh-training-cuda128-torch29-py312"},
-	{Name: "torch-distributed-rocm64-torch29-py312", Image: "odh-training-rocm64-torch29-py312"},
-	{Name: "torch-distributed-cuda130-torch210-py312", Image: "odh-th06-cuda130-torch210-py312"},
-	{Name: "torch-distributed-rocm64-torch291-py312", Image: "odh-th06-rocm64-torch291-py312"},
-	{Name: "torch-distributed-cpu-torch210-py312", Image: "odh-th06-cpu-torch210-py312"},
-	{Name: DefaultTrainingHubRuntimeCUDA, Image: "odh-th06-cuda130-torch210-py312"},
-	{Name: DefaultTrainingHubRuntimeCPU, Image: "odh-th06-cpu-torch210-py312"},
-	{Name: DefaultTrainingHubRuntimeROCm, Image: "odh-th06-rocm64-torch291-py312"},
-	{Name: "training-hub-th05-cuda128-torch29-py312", Image: "odh-training-cuda128-torch29-py312"},
-	{Name: "training-hub-th06-cuda130-torch210-py312", Image: "odh-th06-cuda130-torch210-py312"},
-	{Name: "training-hub-th06-cpu-torch210-py312", Image: "odh-th06-cpu-torch210-py312"},
-	{Name: "training-hub-th06-rocm64-torch291-py312", Image: "odh-th06-rocm64-torch291-py312"},
+	{Name: "torch-distributed-cuda130-torch211-py312", Image: "odh-th-torch-cuda-py312"},
+	{Name: "torch-distributed-rocm714-torch211-py312", Image: "odh-th-torch-rocm-py312"},
+	{Name: "torch-distributed-cpu-torch211-py312", Image: "odh-th-torch-cpu-py312"},
+	{Name: DefaultTrainingHubRuntimeCUDA, Image: "odh-th-torch-cuda-py312"},
+	{Name: DefaultTrainingHubRuntimeCPU, Image: "odh-th-torch-cpu-py312"},
+	{Name: DefaultTrainingHubRuntimeROCm, Image: "odh-th-torch-rocm-py312"},
+	{Name: "training-hub-th09-cuda130-torch211-py312", Image: "odh-th-torch-cuda-py312"},
+	{Name: "training-hub-th09-cpu-torch211-py312", Image: "odh-th-torch-cpu-py312"},
+	{Name: "training-hub-th09-rocm714-torch211-py312", Image: "odh-th-torch-rocm-py312"},
 }
 
 // GetImageFromClusterTrainingRuntime retrieves the container image from the named ClusterTrainingRuntime


### PR DESCRIPTION
## Description
- Align `ExpectedRuntimes` and `TrainingHubToDefaultClusterRuntime` with current trainer CTR manifests ([`manifests/rhoai/runtimes`](https://github.com/opendatahub-io/trainer/tree/main/manifests/rhoai/runtimes))
- Update pinned CTR names from `th06` / `torch210` / `rocm64` to `th09` / `torch211` / `rocm714`
- Update expected images from `odh-th06-*` to `odh-th-torch-{cuda,cpu,rocm}-py312`
- Drop obsolete expected runtimes (`th05`, `cuda128-torch29`, etc.) no longer shipped
- Update CSV `relatedImages` skip matcher from `/odh-th06-` to `/odh-th-torch-`


## How Has This Been Tested?
- [X] `TestDefaultClusterTrainingRuntimes ` - Passed
- [X] `TestDefaultTrainingHubRuntimesMatchDefaultClusterRuntimes ` - Passed

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Updated runtime verification guidance for the default and pinned `th09` Training Hub runtimes.
* Documented the current CUDA runtime image and required `flash-attn` version for GPU testing.
* Updated disconnected-environment guidance with the latest CUDA Python 3.12 image and package requirements.

## Tests
* Updated runtime validation for current `torch-distributed` and `th-torch` image naming.
* Refined related-image matching and removed outdated legacy runtime expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->