### PR TITLE
fix: bind training-edit for SDK tests after TrainJob was detached fro…

### DIFF
--- a/tests/trainer/sdk_tests/failure_traininghub_tests.go
+++ b/tests/trainer/sdk_tests/failure_traininghub_tests.go
@@ -53,7 +53,7 @@ func RunTrainingFailureScenariosTest(t *testing.T) {
 	userName := common.GetNotebookUserName(test)
 	userToken := common.GenerateNotebookUserToken(test)
 	support.CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
-	trainerutils.CreateUserClusterRoleBindingForTrainerRuntimes(test, userName)
+	trainerutils.GrantTrainerUserAccess(test, userName, namespace.Name)
 
 	// Create ConfigMap with notebook
 	localPath := failureNotebookPath
@@ -130,7 +130,7 @@ func RunTorchrunTrainingFailureTest(t *testing.T) {
 	userName := common.GetNotebookUserName(test)
 	userToken := common.GenerateNotebookUserToken(test)
 	support.CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
-	trainerutils.CreateUserClusterRoleBindingForTrainerRuntimes(test, userName)
+	trainerutils.GrantTrainerUserAccess(test, userName, namespace.Name)
 
 	// Create ConfigMap with notebook
 	localPath := torchrunFailureNotebookPath

--- a/tests/trainer/sdk_tests/fashion_mnist_tests.go
+++ b/tests/trainer/sdk_tests/fashion_mnist_tests.go
@@ -55,8 +55,7 @@ func RunFashionMnistCpuDistributedTraining(t *testing.T) {
 	userName := common.GetNotebookUserName(test)
 	userToken := common.GenerateNotebookUserToken(test)
 	support.CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
-	// ClusterRoleBinding for cluster-scoped resources (ClusterTrainingRuntimes) - minimal get/list/watch access
-	trainerutils.CreateUserClusterRoleBindingForTrainerRuntimes(test, userName)
+	trainerutils.GrantTrainerUserAccess(test, userName, namespace.Name)
 
 	// Create ConfigMap with notebook and kubeflow install script
 	nb, err := os.ReadFile(notebookPath)
@@ -149,8 +148,7 @@ func RunFashionMnistKueueCpuDistributedTraining(t *testing.T) {
 	userName := common.GetNotebookUserName(test)
 	userToken := common.GenerateNotebookUserToken(test)
 	support.CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
-	// ClusterRoleBinding for cluster-scoped resources (ClusterTrainingRuntimes) - minimal get/list/watch access
-	trainerutils.CreateUserClusterRoleBindingForTrainerRuntimes(test, userName)
+	trainerutils.GrantTrainerUserAccess(test, userName, namespace.Name)
 
 	// Create Kueue resources
 	resourceFlavor := support.CreateKueueResourceFlavor(test, kueuev1beta2.ResourceFlavorSpec{})

--- a/tests/trainer/sdk_tests/grpo_traininghub_tests.go
+++ b/tests/trainer/sdk_tests/grpo_traininghub_tests.go
@@ -49,7 +49,7 @@ func RunGrpoTrainingHubTraining(t *testing.T, nnodes int) {
 	userName := common.GetNotebookUserName(test)
 	userToken := common.GenerateNotebookUserToken(test)
 	support.CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
-	trainerutils.CreateUserClusterRoleBindingForTrainerRuntimes(test, userName)
+	trainerutils.GrantTrainerUserAccess(test, userName, namespace.Name)
 
 	// Create ConfigMap with notebook and install script
 	localPath := grpoNotebookPath

--- a/tests/trainer/sdk_tests/lora_traininghub_tests.go
+++ b/tests/trainer/sdk_tests/lora_traininghub_tests.go
@@ -49,8 +49,7 @@ func RunLoraTrainingHubMultiGpuDistributedTraining(t *testing.T, nnodes int) {
 	userName := common.GetNotebookUserName(test)
 	userToken := common.GenerateNotebookUserToken(test)
 	support.CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
-	// ClusterRoleBinding for cluster-scoped resources (ClusterTrainingRuntimes) - minimal get/list/watch access
-	trainerutils.CreateUserClusterRoleBindingForTrainerRuntimes(test, userName)
+	trainerutils.GrantTrainerUserAccess(test, userName, namespace.Name)
 
 	// Create ConfigMap with notebook and install script
 	localPath := loraNotebookPath

--- a/tests/trainer/sdk_tests/mpi_tests.go
+++ b/tests/trainer/sdk_tests/mpi_tests.go
@@ -55,7 +55,7 @@ func runOpenMPICudaDistributedTraining(t *testing.T, accelerator support.Acceler
 	userName := common.GetNotebookUserName(test)
 	userToken := common.GenerateNotebookUserToken(test)
 	support.CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
-	trainerutils.CreateUserClusterRoleBindingForTrainerRuntimes(test, userName)
+	trainerutils.GrantTrainerUserAccess(test, userName, namespace.Name)
 
 	var localQueueName string
 	var cleanupKueue func()

--- a/tests/trainer/sdk_tests/osft_traininghub_tests.go
+++ b/tests/trainer/sdk_tests/osft_traininghub_tests.go
@@ -49,8 +49,7 @@ func RunOsftTrainingHubMultiGpuDistributedTraining(t *testing.T, nnodes int) {
 	userName := common.GetNotebookUserName(test)
 	userToken := common.GenerateNotebookUserToken(test)
 	support.CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
-	// ClusterRoleBinding for cluster-scoped resources (ClusterTrainingRuntimes) - minimal get/list/watch access
-	trainerutils.CreateUserClusterRoleBindingForTrainerRuntimes(test, userName)
+	trainerutils.GrantTrainerUserAccess(test, userName, namespace.Name)
 
 	// Create ConfigMap with notebook and install script
 	localPath := osftNotebookPath

--- a/tests/trainer/sdk_tests/rhai_features_tests.go
+++ b/tests/trainer/sdk_tests/rhai_features_tests.go
@@ -259,8 +259,7 @@ func runRhaiFeaturesTestWithConfig(t *testing.T, config RhaiFeatureConfig) {
 	userName := common.GetNotebookUserName(test)
 	userToken := common.GenerateNotebookUserToken(test)
 	CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
-	// ClusterRoleBinding for cluster-scoped resources (ClusterTrainingRuntimes) - minimal get/list/watch access
-	trainerutils.CreateUserClusterRoleBindingForTrainerRuntimes(test, userName)
+	trainerutils.GrantTrainerUserAccess(test, userName, namespace.Name)
 
 	// Create ConfigMap with notebook and install script
 	nb, err := os.ReadFile(config.NotebookPath)

--- a/tests/trainer/sdk_tests/rhai_speculator_tests.go
+++ b/tests/trainer/sdk_tests/rhai_speculator_tests.go
@@ -56,7 +56,7 @@ func setupSpeculatorTestEnv(t *testing.T, pvcSize string) speculatorTestEnv {
 	userName := common.GetNotebookUserName(test)
 	userToken := common.GenerateNotebookUserToken(test)
 	CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
-	trainerutils.CreateUserClusterRoleBindingForTrainerRuntimes(test, userName)
+	trainerutils.GrantTrainerUserAccess(test, userName, namespace.Name)
 
 	nb, err := os.ReadFile(speculatorNotebookPath)
 	test.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to read notebook: %s", speculatorNotebookPath))

--- a/tests/trainer/sdk_tests/sft_traininghub_tests.go
+++ b/tests/trainer/sdk_tests/sft_traininghub_tests.go
@@ -49,8 +49,7 @@ func RunSftTrainingHubMultiGpuDistributedTraining(t *testing.T, nnodes int) {
 	userName := common.GetNotebookUserName(test)
 	userToken := common.GenerateNotebookUserToken(test)
 	support.CreateUserRoleBindingWithClusterRole(test, userName, namespace.Name, "admin")
-	// ClusterRoleBinding for cluster-scoped resources (ClusterTrainingRuntimes) - minimal get/list/watch access
-	trainerutils.CreateUserClusterRoleBindingForTrainerRuntimes(test, userName)
+	trainerutils.GrantTrainerUserAccess(test, userName, namespace.Name)
 
 	// Create ConfigMap with notebook and install script
 	localPath := sftNotebookPath

--- a/tests/trainer/utils/utils_rbac.go
+++ b/tests/trainer/utils/utils_rbac.go
@@ -22,6 +22,20 @@ import (
 	. "github.com/opendatahub-io/distributed-workloads/tests/common/support"
 )
 
+// TrainingEditClusterRole is the RHOAI trainer overlay ClusterRole for TrainJob CRUD.
+// RHOAIENG-83208 / CVE-2026-18951 removed it from default Kubernetes edit aggregation,
+// so tests must RoleBind it explicitly for LDAP/notebook users.
+const TrainingEditClusterRole = "training-edit"
+
+// GrantTrainerUserAccess grants an LDAP/notebook user TrainJob and ClusterTrainingRuntime access.
+// RoleBinding of training-edit covers namespace-scoped TrainJobs; a separate
+// ClusterRoleBinding is required because ClusterTrainingRuntimes are cluster-scoped.
+func GrantTrainerUserAccess(t Test, userName, namespace string) {
+	t.T().Helper()
+	CreateUserRoleBindingWithClusterRole(t, userName, namespace, TrainingEditClusterRole)
+	CreateUserClusterRoleBindingForTrainerRuntimes(t, userName)
+}
+
 // CreateUserClusterRoleBindingForTrainerRuntimes creates a ClusterRole with get/list/watch access
 // to ClusterTrainingRuntimes and binds it to the specified user.
 // This is needed because ClusterTrainingRuntimes are cluster-scoped resources.

--- a/tests/trainer/utils/utils_rbac_test.go
+++ b/tests/trainer/utils/utils_rbac_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trainer
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/opendatahub-io/distributed-workloads/tests/common/support"
+)
+
+func TestGrantTrainerUserAccess(t *testing.T) {
+	test := NewTest(t)
+	namespace := test.NewTestNamespace()
+
+	GrantTrainerUserAccess(test, "ldap-user", namespace.Name)
+
+	rbs, err := test.Client().Core().RbacV1().RoleBindings(namespace.Name).List(test.Ctx(), metav1.ListOptions{})
+	test.Expect(err).NotTo(gomega.HaveOccurred())
+	test.Expect(rbs.Items).To(gomega.HaveLen(1))
+	test.Expect(rbs.Items[0].RoleRef).To(gomega.Equal(rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     TrainingEditClusterRole,
+	}))
+	test.Expect(rbs.Items[0].Subjects).To(gomega.ConsistOf(rbacv1.Subject{
+		Kind:     "User",
+		Name:     "ldap-user",
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+	}))
+
+	crbs, err := test.Client().Core().RbacV1().ClusterRoleBindings().List(test.Ctx(), metav1.ListOptions{})
+	test.Expect(err).NotTo(gomega.HaveOccurred())
+	test.Expect(crbs.Items).To(gomega.HaveLen(1))
+	test.Expect(crbs.Items[0].Subjects[0].Name).To(gomega.Equal("ldap-user"))
+}


### PR DESCRIPTION
## Summary
SDK notebooks authenticate as the Jenkins LDAP user (`NOTEBOOK_TOKEN`), not cluster-admin.
[RHOAIENG-83208](https://issues.redhat.com/browse/RHOAIENG-83208) / CVE-2026-18951 (TRN-02) removed TrainJob CRUD from the default Kubernetes `edit` aggregation. `training-edit` still exists; it is no longer inherited by namespace editors.
This PR RoleBinds `training-edit` in the test namespace for that LDAP user, and keeps the existing ClusterRoleBinding for cluster-scoped ClusterTrainingRuntime get/list/watch.
Helper: `GrantTrainerUserAccess` in `tests/trainer/utils/utils_rbac.go`, wired into all SDK notebook setups (Fashion MNIST, TrainingHub, MPI, RHAI, failure scenarios).
Go tests that use the admin kubeconfig are unchanged.

[RHOAIENG-83208]: https://redhat.atlassian.net/browse/RHOAIENG-83208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trainer access setup across distributed training, fine-tuning, MPI, and RHAI test scenarios.
  * Ensured SDK training tests consistently grant the required namespace and cluster-level permissions.
  * Preserved custom queue configuration for notebook-based training submissions.

* **Tests**
  * Added coverage validating trainer permission bindings and access configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->