### PR TITLE
test: re-enable Kueue TrainJob tests skipped for #3888

### DIFF
--- a/tests/trainer/kubeflow_sdk_test.go
+++ b/tests/trainer/kubeflow_sdk_test.go
@@ -30,7 +30,6 @@ func TestKubeflowSdk(t *testing.T) {
 }
 
 func TestKubeflowSdkKueueIntegration(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, Tier1)
 	test := support.With(t)
 	support.SetupKueue(test, initialKueueState, support.TrainJobFramework)

--- a/tests/trainer/trainer_fashion_mnist_training_test.go
+++ b/tests/trainer/trainer_fashion_mnist_training_test.go
@@ -36,55 +36,46 @@ import (
 )
 
 func TestPyTorchDDPMultiNodeMultiCPUWithTorchCuda28(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, Tier2, MultiNode(2))
 	runPyTorchDDPMultiNodeJob(t, CPU, trainerutils.DefaultClusterTrainingRuntimeCPU, "resources/requirements-cpu.txt", 2, 2)
 }
 
 func TestPyTorchDDPSingleNodeSingleGPUWithTorchCuda(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, KftoCuda, Gpu(NVIDIA))
 	runPyTorchDDPMultiNodeJob(t, NVIDIA, trainerutils.DefaultClusterTrainingRuntimeCUDA, "resources/requirements-cuda.txt", 1, 1)
 }
 
 func TestPyTorchDDPSingleNodeMultiGPUWithTorchCuda(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, KftoCuda, MultiGpu(NVIDIA, 2))
 	runPyTorchDDPMultiNodeJob(t, NVIDIA, trainerutils.DefaultClusterTrainingRuntimeCUDA, "resources/requirements-cuda.txt", 1, 2)
 }
 
 func TestPyTorchDDPMultiNodeSingleGPUWithTorchCuda(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, KftoCuda, MultiNodeGpu(2, NVIDIA))
 	runPyTorchDDPMultiNodeJob(t, NVIDIA, trainerutils.DefaultClusterTrainingRuntimeCUDA, "resources/requirements-cuda.txt", 2, 1)
 }
 
 func TestPyTorchDDPMultiNodeMultiGPUWithTorchCuda(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, KftoCuda, MultiNodeMultiGpu(2, NVIDIA, 2))
 	runPyTorchDDPMultiNodeJob(t, NVIDIA, trainerutils.DefaultClusterTrainingRuntimeCUDA, "resources/requirements-cuda.txt", 2, 2)
 }
 
 func TestPyTorchDDPSingleNodeSingleGPUWithTorchRocm(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, KftoRocm, Gpu(AMD))
 	runPyTorchDDPMultiNodeJob(t, AMD, trainerutils.DefaultClusterTrainingRuntimeROCm, "resources/requirements-rocm.txt", 1, 1)
 }
 
 func TestPyTorchDDPSingleNodeMultiGPUWithTorchRocm(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, KftoRocm, MultiGpu(AMD, 2))
 	runPyTorchDDPMultiNodeJob(t, AMD, trainerutils.DefaultClusterTrainingRuntimeROCm, "resources/requirements-rocm.txt", 1, 2)
 }
 
 func TestPyTorchDDPMultiNodeSingleGPUWithTorchRocm(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, KftoRocm, MultiNodeGpu(2, AMD))
 	runPyTorchDDPMultiNodeJob(t, AMD, trainerutils.DefaultClusterTrainingRuntimeROCm, "resources/requirements-rocm.txt", 2, 1)
 }
 
 func TestPyTorchDDPMultiNodeMultiGPUWithTorchRocm(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, KftoRocm, MultiNodeMultiGpu(2, AMD, 2))
 	runPyTorchDDPMultiNodeJob(t, AMD, trainerutils.DefaultClusterTrainingRuntimeROCm, "resources/requirements-rocm.txt", 2, 2)
 }

--- a/tests/trainer/trainer_kueue_integration_test.go
+++ b/tests/trainer/trainer_kueue_integration_test.go
@@ -57,7 +57,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestKueueWorkloadPreemptionSuspendsTrainJob(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, Tier1)
 	test := With(t)
 	SetupKueue(test, initialKueueState, TrainJobFramework)
@@ -172,7 +171,6 @@ func TestKueueWorkloadPreemptionSuspendsTrainJob(t *testing.T) {
 }
 
 func TestKueueWorkloadInadmissibleWithNonExistentLocalQueue(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, Tier2)
 	test := With(t)
 	SetupKueue(test, initialKueueState, TrainJobFramework)

--- a/tests/trainer/trainer_sft_stock_trl_test.go
+++ b/tests/trainer/trainer_sft_stock_trl_test.go
@@ -37,13 +37,11 @@ import (
 )
 
 func TestSftStockTrlSingleNodeSingleGPU(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, KftoCuda, Gpu(NVIDIA))
 	runSftStockTrlTrainJob(t, NVIDIA, trainerutils.DefaultClusterTrainingRuntimeCUDA, 1, 1)
 }
 
 func TestSftStockTrlSingleNodeSingleGPUWithTorchRocm(t *testing.T) {
-	t.Skip("Skip until upstream Kueue fix is merged, see https://github.com/kubeflow/trainer/issues/3888")
 	Tags(t, KftoRocm, Gpu(AMD))
 	runSftStockTrlTrainJob(t, AMD, trainerutils.DefaultClusterTrainingRuntimeROCm, 1, 1)
 }


### PR DESCRIPTION

## Description

Re-enable the Trainer Kueue tests that were skipped in https://github.com/opendatahub-io/distributed-workloads/commit/9a80a745 while waiting on [kubeflow/trainer#3888](https://github.com/kubeflow/trainer/issues/3888).

Kueue's full-object unsuspend `Update` used to trip TrainJob CEL `self == oldSelf` on explicit `omitempty` zeros (SDK `runtimePatches` with `readOnly: false`, `spec.trainer.env[].value: ""`). The job stayed suspended forever. That is fixed on the Trainer side by moving those immutability checks to the validating webhook ([opendatahub-io/trainer#217](https://github.com/opendatahub-io/trainer/pull/217)), so these tests should run again.

This only removes the `t.Skip` added by that commit. No test logic changes.

### Tests re-enabled

- `TestKubeflowSdkKueueIntegration`
- `TestKueueWorkloadPreemptionSuspendsTrainJob`
- `TestKueueWorkloadInadmissibleWithNonExistentLocalQueue`
- `TestPyTorchDDPMultiNodeMultiCPUWithTorchCuda28` and the CUDA/ROCm DDP variants in `trainer_fashion_mnist_training_test.go`
- `TestSftStockTrlSingleNodeSingleGPU` / `TestSftStockTrlSingleNodeSingleGPUWithTorchRocm`

### Out of scope

Later `#3888` skips in FMS SFT and OpenMPI tests are **not** touched:

- `tests/fms/trainer/sft_trainjob_test.go`
- `tests/fms/trainer/sft_trainjob_gpu_test.go`
- `tests/trainer/trainer_mpi_test.go`
- `tests/trainer/trainer_openmpi_kueue_integration_test.go`

## How Has This Been Tested?

Ran `go test ./tests/trainer -timeout 60m -run Test -v -count=1` against **RHOAI 3.5.0** on `kfto-test-pool-gs94d`, with trainer controller image `quay.io/rh-ee-knema/trainer:kueue-unsuspend-fix-v2` (webhook immutability patch).

Unskipped tests that actually executed:

- `TestPyTorchDDPMultiNodeMultiCPUWithTorchCuda28` — PASS (Kueue admitted, JobSet completed)
- `TestKueueWorkloadPreemptionSuspendsTrainJob` — PASS
- `TestKueueWorkloadInadmissibleWithNonExistentLocalQueue` — PASS
- CUDA/ROCm DDP and SFT variants — SKIP (no GPUs on this cluster)
- `TestKubeflowSdkKueueIntegration` — FAIL in this run because `NOTEBOOK_USER_TOKEN` was empty (fell back to `oc login` without `NOTEBOOK_USER_PASSWORD`). Same test PASSed in a prior run when the token was set from `oc whoami -t`.

Unrelated failures on this cluster (not caused by this PR):

- CTR/operator image prefix checks expect `registry.redhat.io/rhoai/...`; this cluster uses `quay.io/opendatahub/...:odh-stable` and the custom trainer image above
- RHAI notebook tests need a non-empty `NOTEBOOK_USER_TOKEN`
- `TestRhaiS3CheckpointingCPU` needs S3 credentials

## Merge criteria

- [ ] Code changes are covered by tests
- [ ] Commits are squashed into one (or a few logically grouped) Conventional Commit(s)
- [ ] Depends on Trainer webhook immutability fix being available on the cluster under test ([opendatahub-io/trainer#217](https://github.com/opendatahub-io/trainer/pull/217) / equivalent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enabled Kubeflow SDK and Kueue integration tests.
  - Enabled Fashion-MNIST distributed training coverage across CPU, NVIDIA CUDA, and AMD ROCm configurations.
  - Enabled Kueue preemption and invalid LocalQueue scenarios.
  - Enabled single-node, single-GPU SFT Stock TRL tests for NVIDIA and ROCm environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->