### PR TITLE
fix: bump aiohttp to 3.14.3 in py312-cuda130-torch210-openmpi41

### DIFF
--- a/images/runtime/training/py312-cuda130-torch210-openmpi41/pyproject.toml
+++ b/images/runtime/training/py312-cuda130-torch210-openmpi41/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "simpleeval>=0.9.13",
     "safetensors==0.7.0",
     "py-cpuinfo>=9.0.0",
-    "aiohttp==3.13.3",
+    "aiohttp==3.14.3",
 
     # Deep Learning Utilities
     "numba>=0.61.2",

--- a/images/runtime/training/py312-cuda130-torch210-openmpi41/requirements.txt
+++ b/images/runtime/training/py312-cuda130-torch210-openmpi41/requirements.txt
@@ -642,6 +642,7 @@ typer==0.24.1
     #   rhai-innovation-mini-trainer
 typing-extensions==4.15.0
     # via
+    #   aiohttp
     #   aiosignal
     #   alembic
     #   anyio

--- a/images/runtime/training/py312-cuda130-torch210-openmpi41/requirements.txt
+++ b/images/runtime/training/py312-cuda130-torch210-openmpi41/requirements.txt
@@ -21,7 +21,7 @@ aiofiles==25.1.0
     #   training-hub
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.3
     # via
     #   py312-cuda130-torch210-openmpi41 (pyproject.toml)
     #   aiobotocore


### PR DESCRIPTION
## Summary
- Bumps `aiohttp` from 3.13.3 to `==3.14.3` in `images/runtime/training/py312-cuda130-torch210-openmpi41` (`pyproject.toml` + `requirements.txt`).
- Addresses CVE-2026-69244 (OOB heap read in the C response parser; product status: affected before 3.14.3).
- 3.14.3 is on the image AIPCC index (`rhoai/3.4/cuda13.0-ubi9`). Transitive deps already satisfy 3.14.3.

## Test plan
- [ ] `aiohttp==3.14.3` resolves from `--index-url=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda13.0-ubi9/simple/`
- [ ] `pip install -r requirements.txt` / image build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `aiohttp` package to version 3.14.3 in the Python 3.12 CUDA 13.0 training environment.
  * Updated dependency metadata to reflect the new package version and provenance information.
  * No user-facing API or functionality changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->