### PR TITLE
test: add speculator ClusterTrainingRuntimes to expected list

### DIFF
--- a/tests/trainer/cluster_training_runtimes_test.go
+++ b/tests/trainer/cluster_training_runtimes_test.go
@@ -113,6 +113,20 @@ func TestDefaultClusterTrainingRuntimes(t *testing.T) {
 				"Image %s should contain %s", foundImage, expectedImage)
 			test.T().Logf("ClusterTrainingRuntime '%s' uses expected image: %s", expectedRuntime.Name, expectedImage)
 		}
+
+		// For RHOAI, verify all container and init container images use SHA digests
+		if IsRhoai(test) {
+			for _, replicatedJob := range runtime.Spec.Template.Spec.ReplicatedJobs {
+				for _, container := range replicatedJob.Template.Spec.Template.Spec.Containers {
+					test.Expect(container.Image).To(MatchRegexp(`@sha256:[a-f0-9]{64}$`),
+						"Container %s image %s should be SHA-based with valid digest", container.Name, container.Image)
+				}
+				for _, initContainer := range replicatedJob.Template.Spec.Template.Spec.InitContainers {
+					test.Expect(initContainer.Image).To(MatchRegexp(`@sha256:[a-f0-9]{64}$`),
+						"Init container %s image %s should be SHA-based with valid digest", initContainer.Name, initContainer.Image)
+				}
+			}
+		}
 	}
 
 	// Verify all expected runtimes are present
@@ -215,6 +229,10 @@ func TestRunTrainJobWithDefaultClusterTrainingRuntimes(t *testing.T) {
 			test.T().Logf("Skipping MPI runtime '%s' (covered by TestMultiNodeOpenMPITrainJob)", runtime.Name)
 			continue
 		}
+		if trainerutils.IsSpeculatorRuntime(runtime.Name) {
+			test.T().Logf("Skipping speculator runtime '%s' (covered by speculator tests)", runtime.Name)
+			continue
+		}
 		if tested[runtime.Image] {
 			test.T().Logf("Skipping ClusterTrainingRuntime '%s' (image '%s' already tested)", runtime.Name, runtime.Image)
 			continue
@@ -250,7 +268,7 @@ func TestRunTrainJobWithDefaultClusterTrainingRuntimes(t *testing.T) {
 		test.T().Fatalf("TRIGGER_IMAGE_NAME '%s' does not match any expected ClusterTrainingRuntime image", triggerImageName)
 	}
 	if triggerSet && len(tested) == 0 {
-		test.T().Skipf("TRIGGER_IMAGE_NAME '%s' matched only MPI runtimes; covered by TestMultiNodeOpenMPITrainJob", triggerImageName)
+		test.T().Skipf("TRIGGER_IMAGE_NAME '%s' matched only MPI/speculator runtimes; covered by dedicated tests", triggerImageName)
 	}
 
 	test.T().Log("All TrainJobs with expected ClusterTrainingRuntimes completed successfully !!!")


### PR DESCRIPTION
Add speculator-model-opt-cuda and vllm-extract-cuda to ExpectedRuntimes so TestDefaultClusterTrainingRuntimes no longer fails when these runtimes are present on the cluster. Validate their images against the dynamically detected registry via GetExpectedRegistry, including init container images (vllm-sidecar for vllm-extract-cuda).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of cluster training runtime images, including registry, init-container, sidecar, and SHA256-digested images.
  - Added coverage for speculator, vLLM extraction, and model-optimization runtimes.
  - Preserved distinct validation for MPI and default runtimes.

- **Tests**
  - Updated TrainJob smoke tests to appropriately skip speculator and MPI runtime scenarios.
  - Improved messaging when trigger-image tests are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->