### PR TITLE
fix: bump test image base to Go 1.26 to match go.mod

### DIFF
--- a/images/tests/Dockerfile
+++ b/images/tests/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Go image as a base image
-FROM golang:1.25
+FROM golang:1.26
 
 ENV KUBECONFIG=/distributed-workloads/tests/.kube/config
 


### PR DESCRIPTION
The KFT 2.3 upgrade bumped go to 1.26, but dw e2e tests didn't bump it so build has been failing. E.g. [link](https://github.com/opendatahub-io/distributed-workloads/actions/runs/31788470603).

go.mod moved to go 1.26.0 in 94ef61b9 but images/tests/Dockerfile stayed on golang:1.25, so `go mod download` fails with GOTOOLCHAIN=local. The build-and-push-test-images workflow has failed on every push to main since, leaving quay.io/opendatahub/distributed-workloads-tests:latest pinned to the 14 Aug 09:15 build. Nightly runs pull that tag, so none of the trainer test fixes merged since then were being exercised.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the image testing environment to use Go 1.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->