### PR TITLE
Add e2e test asserting Kueue scheduling directives reach TrainJob pods

### DIFF
--- a/tests/trainer/trainer_kueue_integration_test.go
+++ b/tests/trainer/trainer_kueue_integration_test.go
@@ -310,6 +310,14 @@ func TestKueueSchedulingReachesTrainJobPods(t *testing.T) {
 				Name: trainerutils.DefaultClusterTrainingRuntimeCPU,
 			},
 			Trainer: &trainerv1alpha1.Trainer{
+               Command: []string{"echo", "test"},
+               ResourcesPerNode: &corev1.ResourceRequirements{
+                       Requests: corev1.ResourceList{
+                            corev1.ResourceCPU:    resource.MustParse("100m"),
+                            corev1.ResourceMemory: resource.MustParse("128Mi"),
+        },
+    },
+},
 				Command: []string{"echo", "test"},
 			},
 		},

--- a/tests/trainer/trainer_kueue_integration_test.go
+++ b/tests/trainer/trainer_kueue_integration_test.go
@@ -235,3 +235,124 @@ func TestKueueWorkloadInadmissibleWithNonExistentLocalQueue(t *testing.T) {
 
 	test.T().Log("Non-existent LocalQueue causes Workload Inadmissible - verified successfully!")
 }
+
+// TestKueueSchedulingReachesTrainJobPods checks a non-empty ResourceFlavor's node
+// labels/tolerations reach the JobSet pod template, since every other test here uses
+// an empty flavor and never exercises that path. Asserts on the JobSet, not the
+// TrainJob spec, so it holds across Kueue/Trainer versions.
+func TestKueueSchedulingReachesTrainJobPods(t *testing.T) {
+	Tags(t, Tier1)
+	test := With(t)
+	SetupKueue(test, initialKueueState, TrainJobFramework)
+
+	namespace := test.NewTestNamespace(WithKueueManaged()).Name
+	test.T().Logf("Created Kueue-managed namespace: %s", namespace)
+
+	const (
+		flavorNodeLabelKey   = "kueue-test-flavor"
+		flavorNodeLabelValue = "on"
+		flavorTolerationKey  = "kueue-test"
+	)
+
+	resourceFlavor := CreateKueueResourceFlavor(test, kueuev1beta2.ResourceFlavorSpec{
+		NodeLabels: map[string]string{
+			flavorNodeLabelKey: flavorNodeLabelValue,
+		},
+		Tolerations: []corev1.Toleration{
+			{
+				Key:      flavorTolerationKey,
+				Operator: corev1.TolerationOpEqual,
+				Value:    flavorNodeLabelValue,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		},
+	})
+	defer test.Client().Kueue().KueueV1beta2().ResourceFlavors().Delete(test.Ctx(), resourceFlavor.Name, metav1.DeleteOptions{})
+
+	clusterQueue := CreateKueueClusterQueue(test, kueuev1beta2.ClusterQueueSpec{
+		NamespaceSelector: &metav1.LabelSelector{},
+		ResourceGroups: []kueuev1beta2.ResourceGroup{
+			{
+				CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
+				Flavors: []kueuev1beta2.FlavorQuotas{
+					{
+						Name: kueuev1beta2.ResourceFlavorReference(resourceFlavor.Name),
+						Resources: []kueuev1beta2.ResourceQuota{
+							{
+								Name:         corev1.ResourceCPU,
+								NominalQuota: resource.MustParse("8"),
+							},
+							{
+								Name:         corev1.ResourceMemory,
+								NominalQuota: resource.MustParse("16Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	defer test.Client().Kueue().KueueV1beta2().ClusterQueues().Delete(test.Ctx(), clusterQueue.Name, metav1.DeleteOptions{})
+	localQueue := CreateKueueLocalQueue(test, namespace, clusterQueue.Name, AsDefaultQueue)
+
+	// No GPU required: this test only cares about the scheduling directives Kueue
+	// attaches to the JobSet pod template, not about actual training compute.
+	trainJob := &trainerv1alpha1.TrainJob{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-runtimepatches-trainjob-",
+			Namespace:    namespace,
+			Labels: map[string]string{
+				"kueue.x-k8s.io/queue-name": localQueue.Name,
+			},
+		},
+		Spec: trainerv1alpha1.TrainJobSpec{
+			RuntimeRef: trainerv1alpha1.RuntimeRef{
+				Name: trainerutils.DefaultClusterTrainingRuntimeCPU,
+			},
+			Trainer: &trainerv1alpha1.Trainer{
+				Command: []string{"echo", "test"},
+			},
+		},
+	}
+
+	createdTrainJob, err := test.Client().Trainer().TrainerV1alpha1().TrainJobs(namespace).Create(
+		test.Ctx(),
+		trainJob,
+		metav1.CreateOptions{},
+	)
+	test.Expect(err).NotTo(HaveOccurred())
+	test.T().Logf("Created TrainJob: %s", createdTrainJob.Name)
+
+	test.Eventually(KueueWorkloads(test, namespace), TestTimeoutMedium).Should(
+		And(
+			HaveLen(1),
+			ContainElement(WithTransform(KueueWorkloadAdmitted, BeTrue())),
+		),
+	)
+	test.T().Log("Workload admitted")
+
+	// Assert the admitted JobSet's pod template carries the ResourceFlavor's
+	// node label and toleration, however Kueue's TrainJob integration got them there.
+	test.Eventually(SingleJobSet(test, namespace), TestTimeoutMedium).Should(
+		WithTransform(JobSetReplicatedJobsCount, BeNumerically(">", 0)),
+	)
+	jobSet := SingleJobSet(test, namespace)(test)
+
+	for _, replicatedJob := range jobSet.Spec.ReplicatedJobs {
+		podSpec := replicatedJob.Template.Spec.Template.Spec
+		test.Expect(podSpec.NodeSelector).To(
+			HaveKeyWithValue(flavorNodeLabelKey, flavorNodeLabelValue),
+			"replicated job %q should carry the ResourceFlavor's node label", replicatedJob.Name,
+		)
+		test.Expect(podSpec.Tolerations).To(
+			ContainElement(corev1.Toleration{
+				Key:      flavorTolerationKey,
+				Operator: corev1.TolerationOpEqual,
+				Value:    flavorNodeLabelValue,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}),
+			"replicated job %q should carry the ResourceFlavor's toleration", replicatedJob.Name,
+		)
+	}
+	test.T().Logf("JobSet %q pod templates carry the ResourceFlavor's scheduling directives", jobSet.Name)
+}

--- a/tests/trainer/trainer_kueue_integration_test.go
+++ b/tests/trainer/trainer_kueue_integration_test.go
@@ -317,8 +317,14 @@ func TestKueueSchedulingReachesTrainJobPods(t *testing.T) {
                             corev1.ResourceMemory: resource.MustParse("128Mi"),
         },
     },
-},
+			Trainer: &trainerv1alpha1.Trainer{
 				Command: []string{"echo", "test"},
+				ResourcesPerNode: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
 			},
 		},
 	}

--- a/tests/trainer/trainer_kueue_integration_test.go
+++ b/tests/trainer/trainer_kueue_integration_test.go
@@ -310,14 +310,6 @@ func TestKueueSchedulingReachesTrainJobPods(t *testing.T) {
 				Name: trainerutils.DefaultClusterTrainingRuntimeCPU,
 			},
 			Trainer: &trainerv1alpha1.Trainer{
-               Command: []string{"echo", "test"},
-               ResourcesPerNode: &corev1.ResourceRequirements{
-                       Requests: corev1.ResourceList{
-                            corev1.ResourceCPU:    resource.MustParse("100m"),
-                            corev1.ResourceMemory: resource.MustParse("128Mi"),
-        },
-    },
-			Trainer: &trainerv1alpha1.Trainer{
 				Command: []string{"echo", "test"},
 				ResourcesPerNode: &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{


### PR DESCRIPTION
Additional e2e test as part of https://redhat.atlassian.net/browse/RHOAIENG-87834.

Every existing Kueue e2e test creates its ResourceFlavor with an empty spec, so Kueue never computes a pod-level scheduling directive and the podTemplateOverrides/runtimePatches write path is never exercised. This adds a test with a ResourceFlavor carrying real node labels and tolerations, asserting they land on the admitted JobSet's pod template rather than on the TrainJob spec, so it holds regardless of which mechanism the installed Kueue/Trainer version combination uses to get them there.

Relates to https://github.com/red-hat-data-services/trainer/pull/202. The existing e2e tests should pass against this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Tier 1 integration test covering Kueue scheduling for CPU-based training jobs.
  * Verifies scheduling requirements, including node labels and tolerations, are propagated to all training pods after admission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->