### PR TITLE
CVE-2025-15467: rebase training runtime images base ubi9/python-312 to 9.8

### DIFF
--- a/images/runtime/training/py312-cuda128-torch290/Dockerfile
+++ b/images/runtime/training/py312-cuda128-torch290/Dockerfile
@@ -1,5 +1,5 @@
 ## Global Args ######################################################
-ARG IMAGE_TAG=9.7-1767889538
+ARG IMAGE_TAG=9.8-1788919789
 ARG PYTHON_VERSION=312
 
 # use UBI9

--- a/images/runtime/training/py312-rocm64-torch290/Dockerfile
+++ b/images/runtime/training/py312-rocm64-torch290/Dockerfile
@@ -1,5 +1,5 @@
 ## Global Args ######################################################
-ARG IMAGE_TAG=9.7-1767889538
+ARG IMAGE_TAG=9.8-1788919789
 ARG PYTHON_VERSION=312
 
 # use UBI9 latest


### PR DESCRIPTION
## Problem\nCVE-2025-15467 (openssl CMS stack buffer overflow, HIGH 8.8) affects `odh-training-cuda128-torch290` and `odh-training-rocm64-torch290` runtime images.\n\nJira: RHOAIENG-81642, RHOAIENG-81643, RHOAIENG-81644, RHOAIENG-81692, RHOAIENG-81693, RHOAIENG-81694\n\n## Root cause\n`openssl` RPM comes from the pinned UBI base `registry.access.redhat.com/ubi9/python-312:9.7-1767889538` which ships `openssl-3.5.1-5.el9_7` (no RHSA-2026:1473 backport; the 9.7 line never received the fix in python-312 rebuilds — verified on the released images).\n\n## Fix\nRebase the base image to `ubi9/python-312:9.8-1788919789` (current `latest`), which ships `openssl-3.5.5-6.el9_8` (upstream >= 3.5.5 => fixed).\n\nMidstream: bump `ARG IMAGE_TAG` in both torch290 Dockerfiles.\nDownstream (rhoai-3.5): swap the pinned base digest in `Dockerfile.konflux` to `sha256:1918f356719985f9fdae68937d185ffe8a55aa39e00e6a0d07108a0ddd476d9b` (== 9.8-1788919789).